### PR TITLE
[codex] Add meta-language manuscript lint

### DIFF
--- a/src/novel_generator/services/editorial.py
+++ b/src/novel_generator/services/editorial.py
@@ -50,6 +50,18 @@ ABSTRACT_ENDING_PATTERNS = [
     r"the colony breathed",
 ]
 
+META_LANGUAGE_PATTERNS = [
+    r"\bthe chapter ends(?: on| with| by)?\b",
+    r"\bthis (?:lays|sets) (?:the )?groundwork for\b",
+    r"\bthe next problem\b",
+    r"\bpushing the story forward\b",
+    r"\bthe story was not finished\b",
+    r"\bthe decision would shape the next chapter\b",
+    r"\bthis (?:scene|chapter) (?:shows|reveals|establishes|foreshadows|sets up)\b",
+    r"\bthis (?:sets up|foreshadows) (?:the )?next\b",
+    r"\bin the next chapter\b",
+]
+
 ENDING_ACTION_VERBS = {
     "accepts",
     "accepted",
@@ -813,6 +825,14 @@ def _looks_like_internal_or_atmospheric_ending(text: str) -> bool:
     return has_abstract_emotion or has_theme_language
 
 
+def _meta_language_hits(text: str) -> list[str]:
+    hits: list[str] = []
+    for pattern in META_LANGUAGE_PATTERNS:
+        for match in re.finditer(pattern, text, flags=re.IGNORECASE):
+            hits.append(match.group(0).strip())
+    return list(dict.fromkeys(hits))
+
+
 def detect_canonical_entity_collisions(
     existing_entities: list[CanonicalEntity | dict[str, Any]],
     new_entities: list[CanonicalEntity | dict[str, Any]],
@@ -883,6 +903,15 @@ def lint_chapter(
     lowered = content.lower()
     words = _normalized_words(content)
     result = ChapterLintResult()
+
+    meta_language_hits = _meta_language_hits(content)
+    if meta_language_hits:
+        rendered_hits = ", ".join(f"'{hit}'" for hit in meta_language_hits[:5])
+        result.blocking_issues.append(
+            f"Chapter {chapter.chapter_number} contains meta/outlining language {rendered_hits} that belongs in planning notes, not manuscript prose."
+        )
+        result.needs_repair = True
+        result.repair_scope = "targeted_scene_and_ending"
 
     ending_text = _ending_text(content)
     final_beat = _final_beat_text(content)
@@ -1232,6 +1261,12 @@ def lint_manuscript(chapters: list[ChapterDraft]) -> list[str]:
         count = manuscript_text.count(phrase)
         if count >= 4:
             findings.append(f"Repeated stock phrase '{phrase}' appears {count} times.")
+
+    for chapter in chapters:
+        for hit in _meta_language_hits(chapter.content or ""):
+            findings.append(
+                f"Chapter {chapter.chapter_number} contains meta/outlining language '{hit}' that belongs in planning notes, not manuscript prose."
+            )
 
     for previous, current in zip(chapters, chapters[1:]):
         previous_words = set(_normalized_words(previous.summary or previous.content or ""))

--- a/src/novel_generator/services/prompts.py
+++ b/src/novel_generator/services/prompts.py
@@ -480,6 +480,7 @@ def build_chapter_draft_messages(
                 + "; ".join(profile.drafting_focus)
                 + "\n"
                 "- limit new system acronyms in breather or aftermath chapters unless absolutely necessary\n"
+                "- do not include meta-drafting or outline language in the prose, including phrases like 'The chapter ends on', 'This lays the groundwork for', 'pushing the story forward', or 'in the next chapter'\n"
                 "- do not introduce abstract chapter endings about destiny, choices, or the future hanging in the balance\n"
                 "- the final paragraph must include a concrete external action, visible consequence, irreversible decision, reveal, reversal, or state change\n"
                 "- do not end with planning-language such as 'the next problem', 'the next step', 'the choice ahead', or equivalent outline-summary language\n"
@@ -557,6 +558,7 @@ def build_chapter_critique_messages(
                 "}\n\n"
                 "Rules:\n"
                 "- classify ending_hook_type as concrete_action_hook when the final beat is a visible event/action/reversal, resolved_scene_turn when it quietly completes the scene turn with a tangible decision or state change, abstract_cliffhanger when it only gestures at future stakes, image_or_feeling_beat when it ends on mood/image without external consequence, or outline_summary when it uses planning language such as 'next problem' or 'next step'\n"
+                "- set revision_required to true if any draft prose contains meta/outlining language such as 'The chapter ends on', 'This lays the groundwork for', 'pushing the story forward', 'The story was not finished', 'the decision would shape the next chapter', or 'in the next chapter'\n"
                 "- set revision_required to true if the chapter has an abstract ending, outline-summary ending, image/feeling-only ending, unresolved immediate scene turn, zero-cost major solution, repeated emergency mechanics, repeated premise beat, side character who only helps or warns, proper-noun inconsistency, emotional fallout that disappears, blurred ideology positions, or weak style/voice delivery\n"
                 "- use repair_scope 'voice_and_texture' when the main problem is flat prose, samey dialogue, repeated sentence rhythm, weak sensory specificity, or poor style-profile alignment\n"
                 "- use repair_scope 'targeted_scene_and_ending' for ending, cost, repetition-fatigue, or side-character pressure problems\n"
@@ -626,6 +628,7 @@ def build_chapter_revision_messages(
                 "- if repair_scope is 'full_chapter', rebuild the chapter so it stops repeating the premise and restores continuity\n"
                 "- if ending_hook_type is abstract_cliffhanger, image_or_feeling_beat, or outline_summary, replace the final beat with a concrete external action, visible consequence, irreversible decision, reveal, reversal, or state change\n"
                 "- make the revised ending resolve the chapter's immediate scene tension while opening the next problem through something visible on the page\n"
+                "- remove meta/outlining language such as 'The chapter ends on', 'This lays the groundwork for', 'The next problem', 'pushing the story forward', 'The story was not finished', 'the decision would shape the next chapter', or 'in the next chapter' while preserving the actual scene event\n"
                 "- do not end with planning-language such as 'the next problem', 'the next step', 'the choice ahead', or equivalent outline-summary language\n"
                 "- follow the prose style profile's narrative_voice, sentence_rhythm, imagery_palette, dialogue_rules, character_voice_map, and avoid list\n"
                 "- do not copy exact language from any user-provided style reference\n"
@@ -799,7 +802,7 @@ def build_manuscript_qa_messages(
                 '  "genre_contract_notes": ["string"]\n'
                 "}\n\n"
                 "Be specific about repeated setups, duplicated endings, abstract or outline-summary endings, continuity instability, easy technical wins, side-character flatness, "
-                "proper-noun drift, emotional pacing, ideology blur, civilian-life absence, repeated emergency mechanics such as lockdown, quarantine, reboot, alarm, warning banner, reserve drain, core temperature, critical failure, drone breach, override, or countdown, and whether the manuscript delivers on the ending promise. "
+                "meta/outlining language in chapter prose, proper-noun drift, emotional pacing, ideology blur, civilian-life absence, repeated emergency mechanics such as lockdown, quarantine, reboot, alarm, warning banner, reserve drain, core temperature, critical failure, drone breach, override, or countdown, and whether the manuscript delivers on the ending promise. "
                 "Genre contract notes must judge the selected profile: "
                 + "; ".join(profile.qa_focus or profile.genre_contract)
             ),

--- a/tests/test_editorial.py
+++ b/tests/test_editorial.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from novel_generator.models import ChapterDraft, ChapterStatus
-from novel_generator.services.editorial import detect_canonical_entity_collisions, lint_chapter, manuscript_quality_notes
+from novel_generator.services.editorial import (
+    detect_canonical_entity_collisions,
+    lint_chapter,
+    lint_manuscript,
+    manuscript_quality_notes,
+)
 
 
 def _story_bible() -> dict:
@@ -155,6 +160,39 @@ def test_chapter_lint_flags_outline_summary_ending_language() -> None:
     assert result.needs_repair is True
     assert result.repair_scope == "targeted_scene_and_ending"
     assert any("outline-summary language" in item.lower() for item in result.blocking_issues)
+
+
+def test_chapter_lint_flags_meta_language_variants_anywhere_in_prose() -> None:
+    variants = [
+        ("The chapter ends on Mara opening the archive hatch.", "The chapter ends on"),
+        ("This lays the groundwork for Mara's later rebellion.", "This lays the groundwork for"),
+        ("The next problem becomes whether Nadia can trust her.", "The next problem"),
+        ("The scene keeps pushing the story forward.", "pushing the story forward"),
+        ("The story was not finished after the archive opened.", "The story was not finished"),
+        ("The decision would shape the next chapter.", "The decision would shape the next chapter"),
+        ("This chapter establishes Nadia's distrust.", "This chapter establishes"),
+        ("In the next chapter, Mara will face the watchdog.", "In the next chapter"),
+    ]
+
+    for variant, expected_hit in variants:
+        chapter = ChapterDraft(
+            chapter_number=2,
+            title="Watchdog",
+            outline_summary="Mara proves the patch is manipulating compliance.",
+            content=(
+                "Mara got the logs open while Nadia braced the archive hatch. "
+                f"{variant} "
+                "A drone stopped outside the hatch. Its lens turned blue. It spoke in Nadia's voice."
+            ),
+            status=ChapterStatus.PENDING,
+        )
+
+        result = lint_chapter(chapter, _outline_entry(), _plan(), _story_bible(), _ledger(), [])
+
+        joined = " ".join(result.blocking_issues).lower()
+        assert result.needs_repair is True
+        assert "meta/outlining language" in joined
+        assert expected_hit.lower() in joined
 
 
 def test_chapter_lint_flags_final_beat_without_external_action() -> None:
@@ -364,6 +402,29 @@ def test_manuscript_quality_notes_tracks_repeated_emergency_mechanics() -> None:
 
     assert any("Chapters 1-2 repeat emergency mechanics" in item for item in notes["technical_escalation_fatigue_findings"])
     assert any("Manuscript repeatedly returns" in item for item in notes["technical_escalation_fatigue_findings"])
+
+
+def test_manuscript_lint_reports_meta_language_with_chapter_and_phrase() -> None:
+    chapters = [
+        ChapterDraft(
+            chapter_number=1,
+            title="Signal",
+            outline_summary="Mara discovers the patch.",
+            content=(
+                "Mara opened the hatch while Nadia sealed the vault record. "
+                "This lays the groundwork for the next confrontation."
+            ),
+            summary="Mara opens the hatch.",
+            status=ChapterStatus.COMPLETED,
+        )
+    ]
+
+    findings = lint_manuscript(chapters)
+
+    assert any(
+        "Chapter 1 contains meta/outlining language 'This lays the groundwork for'" in item
+        for item in findings
+    )
 
 
 def test_manuscript_quality_notes_tracks_side_character_decision_coverage() -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -692,10 +692,12 @@ def test_prompt_builders_include_prose_voice_profile() -> None:
     assert "technical_escalation_fatigue_score" in critique_prompt
     assert "abstract_cliffhanger" in critique_prompt
     assert "next problem" in critique_prompt
+    assert "meta/outlining language" in critique_prompt
     assert "lockdowns, quarantines, reboots, alarms" in critique_prompt
     assert "side_character_independence_score should be 5 or lower" in critique_prompt
     assert "voice_and_texture" in critique_prompt
     assert "concrete external action" in revision_prompt
+    assert "remove meta/outlining language" in revision_prompt
     assert "remove repeated alarm-console escalation" in revision_prompt
     assert "add or sharpen the planned independent_side_character_move" in revision_prompt
     assert "voice_and_texture" in revision_prompt


### PR DESCRIPTION
## What changed

- Added deterministic detection for meta/outlining language inside chapter prose, including phrases like `The chapter ends on`, `This lays the groundwork for`, `pushing the story forward`, and `in the next chapter`.
- Surfaced exact phrase hits with chapter numbers in manuscript-level QA lint findings.
- Updated drafting, critique, revision, and manuscript QA prompts so leaked planning language is removed while preserving the actual scene event.
- Added focused tests covering eight forbidden phrase variants plus manuscript QA reporting.

Fixes #14.

## Validation

- `git diff --check`
- Could not run pytest locally because no Python interpreter is available on PATH and Docker Desktop could not be started from this session.