### PR TITLE
[codex] Add scene-mode variety constraints

### DIFF
--- a/src/novel_generator/schemas.py
+++ b/src/novel_generator/schemas.py
@@ -10,6 +10,51 @@ from .models import ChapterStatus, RunStatus
 from .services.genre_profiles import DEFAULT_GENRE_PROFILE, GENRE_PROFILES
 
 
+ALLOWED_CHAPTER_MODES = {
+    "investigation",
+    "interpersonal_confrontation",
+    "public_debate",
+    "family_private_emotional_scene",
+    "physical_escape",
+    "civic_fallout",
+    "technical_operation",
+    "moral_negotiation",
+    "quiet_reflection",
+    "public_uprising",
+    "governance_rebuilding",
+    "systems_crisis",
+    "breather",
+    "aftermath",
+    "reversal",
+}
+
+CHAPTER_MODE_ALIASES = {
+    "confrontation": "interpersonal_confrontation",
+    "interpersonal confrontation": "interpersonal_confrontation",
+    "public debate": "public_debate",
+    "family/private emotional scene": "family_private_emotional_scene",
+    "family private emotional scene": "family_private_emotional_scene",
+    "physical escape": "physical_escape",
+    "civic fallout / civilian aftermath": "civic_fallout",
+    "civic fallout": "civic_fallout",
+    "civilian aftermath": "civic_fallout",
+    "technical operation": "technical_operation",
+    "moral negotiation": "moral_negotiation",
+    "quiet reflection": "quiet_reflection",
+    "public uprising": "public_uprising",
+    "governance/rebuilding": "governance_rebuilding",
+    "governance rebuilding": "governance_rebuilding",
+    "systems crisis": "systems_crisis",
+}
+
+
+def normalize_chapter_mode(value: Any) -> str:
+    rendered = str(value or "").strip().lower().replace("-", "_")
+    rendered = " ".join(rendered.split())
+    rendered = CHAPTER_MODE_ALIASES.get(rendered, rendered.replace(" ", "_"))
+    return rendered
+
+
 def _clean_list(value: Any) -> list[str]:
     if value is None:
         return []
@@ -240,6 +285,11 @@ class StructuredOutlineEntry(BaseModel):
     def validate_genre_specific_beats(cls, value: Any) -> list[str]:
         return _clean_list(value)
 
+    @field_validator("chapter_mode", mode="before")
+    @classmethod
+    def validate_chapter_mode(cls, value: Any) -> str:
+        return normalize_chapter_mode(value)
+
 
 class ContinuityLedger(BaseModel):
     current_patch_status: str
@@ -266,6 +316,7 @@ class ContinuityLedger(BaseModel):
 
 
 class ChapterPlan(BaseModel):
+    chapter_mode: str = ""
     opening_state: str
     character_goal: str
     scene_beats: list[str] = Field(default_factory=list)
@@ -288,6 +339,11 @@ class ChapterPlan(BaseModel):
     @classmethod
     def validate_plan_genre_specific_beats(cls, value: Any) -> list[str]:
         return _clean_list(value)
+
+    @field_validator("chapter_mode", mode="before")
+    @classmethod
+    def validate_chapter_mode(cls, value: Any) -> str:
+        return normalize_chapter_mode(value)
 
 
 class ChapterContinuityUpdate(BaseModel):
@@ -438,6 +494,7 @@ class ManuscriptQaReport(BaseModel):
     ideology_consistency_findings: list[str] = Field(default_factory=list)
     civilian_texture_findings: list[str] = Field(default_factory=list)
     technical_escalation_fatigue_findings: list[str] = Field(default_factory=list)
+    scene_mode_distribution_notes: list[str] = Field(default_factory=list)
     genre_contract_notes: list[str] = Field(default_factory=list)
 
     @field_validator("overall_verdict", mode="before")
@@ -462,6 +519,7 @@ class ManuscriptQaReport(BaseModel):
         "ideology_consistency_findings",
         "civilian_texture_findings",
         "technical_escalation_fatigue_findings",
+        "scene_mode_distribution_notes",
         "genre_contract_notes",
         mode="before",
     )

--- a/src/novel_generator/services/editorial.py
+++ b/src/novel_generator/services/editorial.py
@@ -13,6 +13,7 @@ from ..schemas import (
     ManuscriptQaReport,
     StoryBible,
     StructuredOutlineEntry,
+    normalize_chapter_mode,
 )
 
 
@@ -27,6 +28,8 @@ STOCK_PHRASES = [
 ]
 
 BREATHER_MODES = {"breather", "aftermath"}
+
+TECHNICAL_SCENE_MODES = {"systems_crisis", "technical_operation"}
 
 ABSTRACT_ENDING_PATTERNS = [
     r"\bnext problem\b",
@@ -635,6 +638,15 @@ def _technical_fatigue_labels(hits: Counter[str], limit: int = 5) -> list[str]:
     return sorted(hits, key=lambda label: (-hits[label], label))[:limit]
 
 
+def _chapter_mode_from_summary(summary: str) -> str:
+    match = re.search(
+        r"\bMode:\s*([^.;\n]+?)(?=\s+(?:Obstacle|Conflict turn|Reveal|Cost if success|Ending state|Genre state):|[.;\n]|$)",
+        summary or "",
+        flags=re.IGNORECASE,
+    )
+    return normalize_chapter_mode(match.group(1)) if match else ""
+
+
 def _adjacent_prior_chapter(chapter_number: int, prior_chapters: list[ChapterDraft]) -> ChapterDraft | None:
     candidates = [
         previous
@@ -1054,7 +1066,7 @@ def lint_chapter(
         result.needs_repair = True
         result.repair_scope = "targeted_scene_and_ending"
 
-    chapter_mode = str(entry.get("chapter_mode", "")).strip().lower()
+    chapter_mode = normalize_chapter_mode(chapter_plan.get("chapter_mode") or entry.get("chapter_mode", ""))
     if chapter_mode in BREATHER_MODES:
         civilian_terms = _meaningful_terms(str(entry.get("civilian_life_detail", "")))
         emotional_terms = _meaningful_terms(str(entry.get("emotional_reveal", "")))
@@ -1167,6 +1179,7 @@ def lint_chapter(
     adjacent_hits = _technical_fatigue_hits(adjacent_chapter.content or "") if adjacent_chapter else Counter()
     adjacent_overlap = set(fatigue_hits) & set(adjacent_hits)
     fatigue_score = _technical_fatigue_score(fatigue_hits, len(adjacent_overlap))
+    adjacent_mode = _chapter_mode_from_summary(adjacent_chapter.outline_summary or "") if adjacent_chapter else ""
     if fatigue_score >= 6:
         labels = _technical_fatigue_labels(fatigue_hits)
         message = (
@@ -1184,6 +1197,21 @@ def lint_chapter(
         result.soft_warnings.append(
             f"Chapter {chapter.chapter_number} repeats technical emergency mechanics from adjacent chapter "
             f"{adjacent_chapter.chapter_number}: {', '.join(sorted(adjacent_overlap)[:5])}."
+        )
+        result.needs_repair = True
+        result.repair_scope = "targeted_scene_and_ending"
+    if adjacent_chapter and adjacent_mode and adjacent_mode == chapter_mode and adjacent_overlap:
+        result.soft_warnings.append(
+            f"Chapter {chapter.chapter_number} repeats the same scene mode as adjacent chapter "
+            f"{adjacent_chapter.chapter_number} ({chapter_mode}) and reuses crisis mechanics: "
+            + ", ".join(sorted(adjacent_overlap)[:5])
+            + ". Vary the dominant dramatic mode or replace the repeated mechanic."
+        )
+        result.needs_repair = True
+        result.repair_scope = "targeted_scene_and_ending"
+    if chapter_mode and chapter_mode not in TECHNICAL_SCENE_MODES and fatigue_score >= 4:
+        result.soft_warnings.append(
+            f"Chapter {chapter.chapter_number} is tagged as {chapter_mode} but the prose falls back into technical crisis mechanics."
         )
         result.needs_repair = True
         result.repair_scope = "targeted_scene_and_ending"
@@ -1309,6 +1337,7 @@ def manuscript_quality_notes(
         "ideology_consistency_findings": [],
         "civilian_texture_findings": [],
         "technical_escalation_fatigue_findings": [],
+        "scene_mode_distribution_notes": [],
         "genre_contract_notes": [],
     }
 
@@ -1388,6 +1417,37 @@ def manuscript_quality_notes(
                 + ", ".join(sorted(overlap)[:5])
                 + "."
             )
+        previous_mode = _chapter_mode_from_summary(previous.outline_summary or "")
+        current_mode = _chapter_mode_from_summary(current.outline_summary or "")
+        if previous_mode and current_mode and previous_mode == current_mode:
+            if overlap:
+                notes["scene_mode_distribution_notes"].append(
+                    f"Chapters {previous.chapter_number}-{current.chapter_number} repeat scene mode {current_mode} and crisis mechanics: "
+                    + ", ".join(sorted(overlap)[:5])
+                    + "."
+                )
+            else:
+                notes["scene_mode_distribution_notes"].append(
+                    f"Chapters {previous.chapter_number}-{current.chapter_number} repeat scene mode {current_mode}; consider varying the dominant dramatic mode."
+                )
+
+    chapter_modes = [
+        _chapter_mode_from_summary(chapter.outline_summary or "")
+        for chapter in sorted_chapters
+    ]
+    chapter_modes = [mode for mode in chapter_modes if mode]
+    if chapter_modes:
+        mode_counts = Counter(chapter_modes)
+        distribution = ", ".join(
+            f"{mode}: {count}"
+            for mode, count in sorted(mode_counts.items(), key=lambda item: (-item[1], item[0]))
+        )
+        notes["scene_mode_distribution_notes"].append(f"Scene mode distribution: {distribution}.")
+        dominant_mode, dominant_count = mode_counts.most_common(1)[0]
+        if len(chapter_modes) >= 4 and dominant_count / len(chapter_modes) > 0.5:
+            notes["scene_mode_distribution_notes"].append(
+                f"Scene mode {dominant_mode} dominates {dominant_count} of {len(chapter_modes)} chapters; broaden the chapter-mode mix."
+            )
 
     mechanic_chapter_counts: Counter[str] = Counter()
     for hits in chapter_fatigue_hits.values():
@@ -1455,6 +1515,7 @@ def manuscript_quality_notes(
     notes["ideology_consistency_findings"] = list(dict.fromkeys(notes["ideology_consistency_findings"]))
     notes["civilian_texture_findings"] = list(dict.fromkeys(notes["civilian_texture_findings"]))
     notes["technical_escalation_fatigue_findings"] = list(dict.fromkeys(notes["technical_escalation_fatigue_findings"]))
+    notes["scene_mode_distribution_notes"] = list(dict.fromkeys(notes["scene_mode_distribution_notes"]))
     notes["genre_contract_notes"] = list(dict.fromkeys(notes["genre_contract_notes"]))
     return notes
 
@@ -1520,6 +1581,10 @@ def render_qa_report_markdown(report: ManuscriptQaReport) -> str:
         "## Technical Escalation Fatigue",
         "",
         *([f"- {item}" for item in report.technical_escalation_fatigue_findings] or ["- No technical escalation fatigue findings recorded."]),
+        "",
+        "## Scene Mode Distribution",
+        "",
+        *([f"- {item}" for item in report.scene_mode_distribution_notes] or ["- No scene-mode distribution notes recorded."]),
         "",
         "## Genre Contract",
         "",

--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 import json
+import re
 from typing import Any, Callable
 
 from sqlalchemy.orm import Session
@@ -17,6 +18,7 @@ from ..schemas import (
     ManuscriptQaReport,
     StoryBible,
     StructuredOutlineEntry,
+    normalize_chapter_mode,
 )
 from ..settings import Settings
 from .editorial import (
@@ -114,6 +116,51 @@ def _require_requested_chapters(session: Session, run: GenerationRun) -> list:
 
 def _sync_summary_context(run: GenerationRun, window: int) -> None:
     run.summary_context = rolling_context(run.chapters, window)
+
+
+def _recent_mode_entries(value: str) -> list[tuple[int, str]]:
+    entries: list[tuple[int, str]] = []
+    for part in str(value or "").split(";"):
+        part = part.strip()
+        if not part.lower().startswith("chapter "):
+            continue
+        match = re.match(r"chapter\s+(\d+)\s*:\s*(.+)", part, flags=re.IGNORECASE)
+        if not match:
+            continue
+        chapter_number = int(match.group(1))
+        mode_text = match.group(2)
+        mode = normalize_chapter_mode(mode_text)
+        if mode:
+            entries.append((chapter_number, mode))
+    return entries
+
+
+def _ledger_with_chapter_mode(
+    ledger: ContinuityLedger,
+    chapter_number: int,
+    chapter_mode: str,
+) -> ContinuityLedger:
+    mode = normalize_chapter_mode(chapter_mode)
+    if not mode:
+        return ledger
+
+    recent_entries = [
+        entry
+        for entry in _recent_mode_entries(ledger.genre_state.get("recent_chapter_modes", ""))
+        if entry[0] != chapter_number
+    ]
+    recent_entries.append((chapter_number, mode))
+    recent_entries = recent_entries[-2:]
+    recent_rendered = "; ".join(f"Chapter {number}: {entry_mode}" for number, entry_mode in recent_entries)
+    return ledger.model_copy(
+        update={
+            "genre_state": {
+                **ledger.genre_state,
+                "last_chapter_mode": mode,
+                "recent_chapter_modes": recent_rendered,
+            }
+        }
+    )
 
 
 def _ensure_not_canceled(session: Session, run: GenerationRun) -> None:
@@ -662,6 +709,7 @@ def _draft_chapter(
         f"chapter {chapter.chapter_number} continuity update",
     )
     ledger_after = _ledger_from_update(ledger, continuity_update)
+    ledger_after = _ledger_with_chapter_mode(ledger_after, chapter.chapter_number, outline_entry.chapter_mode)
     if continuity_update.timeline != ledger_after.timeline:
         continuity_update.timeline = ledger_after.timeline
     _apply_continuity_canon_warnings(chapter, continuity_update)
@@ -759,6 +807,12 @@ def _run_manuscript_qa(
                     *deterministic_notes["technical_escalation_fatigue_findings"],
                 ]
             ),
+            "scene_mode_distribution_notes": _dedupe(
+                [
+                    *qa_report.scene_mode_distribution_notes,
+                    *deterministic_notes["scene_mode_distribution_notes"],
+                ]
+            ),
             "genre_contract_notes": _dedupe(
                 [*qa_report.genre_contract_notes, *deterministic_notes["genre_contract_notes"]]
             ),
@@ -791,6 +845,8 @@ def process_run(session: Session, run: GenerationRun, settings: Settings, client
         if chapter.status == ChapterStatus.COMPLETED and chapter.content and chapter.summary and chapter.continuity_update:
             ledger = _continuity_ledger_from_run(run)
             ledger_after = _ledger_from_update(ledger, ChapterContinuityUpdate.model_validate(chapter.continuity_update))
+            outline_entry = _outline_entry(run, chapter.chapter_number)
+            ledger_after = _ledger_with_chapter_mode(ledger_after, chapter.chapter_number, outline_entry.chapter_mode)
             run.continuity_ledger = ledger_after.model_dump()
             _sync_summary_context(run, settings.chapter_summary_window)
             session.commit()

--- a/src/novel_generator/services/prompts.py
+++ b/src/novel_generator/services/prompts.py
@@ -9,6 +9,7 @@ from pydantic import TypeAdapter, ValidationError
 
 from ..models import ChapterDraft, GenerationRun, Project
 from ..schemas import (
+    ALLOWED_CHAPTER_MODES,
     ChapterContinuityUpdate,
     ChapterCritique,
     ChapterPlan,
@@ -18,6 +19,10 @@ from ..schemas import (
     StructuredOutlineEntry,
 )
 from .genre_profiles import GenreProfile, genre_profile
+
+
+def _chapter_mode_options() -> str:
+    return "|".join(sorted(ALLOWED_CHAPTER_MODES))
 
 
 def _project_genre_profile(project: Project) -> GenreProfile:
@@ -249,6 +254,7 @@ def build_story_bible_messages(project: Project, run: GenerationRun) -> list[dic
 def build_outline_messages(project: Project, run: GenerationRun, story_bible: StoryBible | dict[str, Any]) -> list[dict[str, str]]:
     bible = story_bible if isinstance(story_bible, dict) else story_bible.model_dump()
     profile = _story_bible_genre_profile(bible)
+    chapter_mode_options = _chapter_mode_options()
     minimum_setbacks = max(1, math.ceil(run.requested_chapters * 0.3))
     midpoint_start = max(2, math.ceil(run.requested_chapters * 0.4))
     midpoint_end = max(midpoint_start, math.floor(run.requested_chapters * 0.7))
@@ -294,7 +300,7 @@ def build_outline_messages(project: Project, run: GenerationRun, story_bible: St
                 '        "visible_object_or_actor": "string",\n'
                 '        "next_problem": "string"\n'
                 "      },\n"
-                '      "chapter_mode": "investigation|systems_crisis|breather|aftermath|confrontation|reversal",\n'
+                f'      "chapter_mode": "{chapter_mode_options}",\n'
                 '      "civilian_life_detail": "string",\n'
                 '      "emotional_reveal": "string",\n'
                 '      "ideology_pressure": "string",\n'
@@ -312,6 +318,10 @@ def build_outline_messages(project: Project, run: GenerationRun, story_bible: St
                 "- no more than 2 consecutive clean wins are allowed\n"
                 f"{midpoint_rule}"
                 "- every block of 4 chapters must contain at least 1 chapter_mode of breather or aftermath\n"
+                "- choose chapter_mode as the dominant dramatic mode, not just the location or prop used in the scene\n"
+                f"- use only these chapter_mode values: {chapter_mode_options}\n"
+                "- build an intentional distribution of chapter_mode values across the whole book\n"
+                "- no chapter may repeat the same chapter_mode used by either of the previous 2 chapters unless the story is in one continuous unavoidable sequence\n"
                 "- side_character_friction must name who pushes back on the protagonist and why\n"
                 "- independent_side_character_move must name a side character action that changes the protagonist's options through cost, reveal, betrayal, rescue, escalation, public consequence, or political constraint\n"
                 "- cost_if_success must describe the price of progress, not just the risk of failure\n"
@@ -356,6 +366,9 @@ def build_chapter_plan_messages(
     ledger = continuity_ledger if isinstance(continuity_ledger, dict) else continuity_ledger.model_dump()
     profile = _story_bible_genre_profile(bible)
     relevant_canon = _filter_canon_registry(bible, entry, ledger)
+    genre_state = ledger.get("genre_state") or {}
+    recent_chapter_modes = str(genre_state.get("recent_chapter_modes", "") or "").strip()
+    chapter_mode_options = _chapter_mode_options()
     return [
         {
             "role": "system",
@@ -374,9 +387,11 @@ def build_chapter_plan_messages(
                 f"Selected genre profile:\n{_genre_profile_block(profile)}\n\n"
                 f"Relevant canon registry for this chapter:\n{json.dumps(relevant_canon, indent=2)}\n\n"
                 f"Continuity ledger:\n{json.dumps(ledger, indent=2)}\n\n"
+                f"Recent chapter modes to avoid repeating:\n{recent_chapter_modes or 'No recent chapter modes tracked yet.'}\n\n"
                 f"Current chapter outline:\n{json.dumps(entry, indent=2)}\n\n"
                 "Return a JSON object with exactly these keys:\n"
                 "{\n"
+                f'  "chapter_mode": "{chapter_mode_options}",\n'
                 '  "opening_state": "string",\n'
                 '  "character_goal": "string",\n'
                 '  "scene_beats": ["beat 1", "beat 2", "beat 3", "beat 4"],\n'
@@ -396,6 +411,9 @@ def build_chapter_plan_messages(
                 '  "genre_specific_beats": ["profile-specific beat 1", "profile-specific beat 2"]\n'
                 "}\n\n"
                 "Rules:\n"
+                f"- use only these chapter_mode values: {chapter_mode_options}\n"
+                "- set chapter_mode to the current outline chapter_mode unless that would repeat a mode from the previous 2 chapters; if it would repeat, choose the closest non-repeating dramatic mode that preserves the same plot outcome\n"
+                "- chapter_mode must describe the dominant dramatic mode of the planned scene, not the presence of a console, alarm, drone, or system prop\n"
                 "- include 4 to 6 concrete scene beats\n"
                 "- at least one beat must materially worsen or transform the conflict\n"
                 "- if the protagonist uses a technical solution, the plan must include a visible cost or exposure\n"
@@ -466,6 +484,7 @@ def build_chapter_draft_messages(
                 "- if side_character_friction exists, the side character must push back from their own agenda\n"
                 "- if independent_side_character_move exists, put that side character's concrete action on the page and make it alter the protagonist's options\n"
                 "- side characters who appear must pursue their own want through action, not only warn, explain, oppose, or validate the protagonist\n"
+                "- honor chapter_plan.chapter_mode as the dominant dramatic mode; do not let a non-technical mode collapse back into console -> alarm -> drone machinery\n"
                 "- keep names, aliases, systems, projects, and locations consistent with the canon registry\n"
                 "- if chapter_mode is breather or aftermath, make face-to-face emotional conflict the primary motion instead of another terminal emergency\n"
                 "- include the civilian_life_detail and emotional_reveal explicitly on the page\n"
@@ -799,10 +818,11 @@ def build_manuscript_qa_messages(
                 '  "ideology_consistency_findings": ["string"],\n'
                 '  "civilian_texture_findings": ["string"],\n'
                 '  "technical_escalation_fatigue_findings": ["string"],\n'
+                '  "scene_mode_distribution_notes": ["string"],\n'
                 '  "genre_contract_notes": ["string"]\n'
                 "}\n\n"
                 "Be specific about repeated setups, duplicated endings, abstract or outline-summary endings, continuity instability, easy technical wins, side-character flatness, "
-                "meta/outlining language in chapter prose, proper-noun drift, emotional pacing, ideology blur, civilian-life absence, repeated emergency mechanics such as lockdown, quarantine, reboot, alarm, warning banner, reserve drain, core temperature, critical failure, drone breach, override, or countdown, and whether the manuscript delivers on the ending promise. "
+                "meta/outlining language in chapter prose, chapter_mode distribution and adjacent mode repetition, proper-noun drift, emotional pacing, ideology blur, civilian-life absence, repeated emergency mechanics such as lockdown, quarantine, reboot, alarm, warning banner, reserve drain, core temperature, critical failure, drone breach, override, or countdown, and whether the manuscript delivers on the ending promise. "
                 "Genre contract notes must judge the selected profile: "
                 + "; ".join(profile.qa_focus or profile.genre_contract)
             ),
@@ -916,6 +936,14 @@ def parse_outline(text: str, requested_chapters: int) -> list[dict[str, Any]]:
     if any(not item.chapter_mode.strip() for item in outline):
         raise ValueError("Outline entries must include a chapter_mode for every chapter.")
 
+    invalid_modes = sorted({item.chapter_mode for item in outline if item.chapter_mode not in ALLOWED_CHAPTER_MODES})
+    if invalid_modes:
+        raise ValueError(
+            "Outline entries use unsupported chapter_mode values: "
+            + ", ".join(invalid_modes)
+            + "."
+        )
+
     minimum_setbacks = max(1, math.ceil(requested_chapters * 0.3))
     setback_count = sum(1 for item in outline if item.outcome_type.lower() in {"setback", "reversal"})
     if setback_count < minimum_setbacks:
@@ -967,6 +995,13 @@ def parse_outline(text: str, requested_chapters: int) -> list[dict[str, Any]]:
                 raise ValueError(
                     f"Outline must include a breather or aftermath chapter between chapters {start_number} and {end_number}."
                 )
+
+    for index, item in enumerate(outline):
+        recent_modes = {previous.chapter_mode for previous in outline[max(0, index - 2) : index]}
+        if item.chapter_mode in recent_modes:
+            raise ValueError(
+                f"Chapter {item.chapter_number} repeats chapter_mode '{item.chapter_mode}' from one of the previous 2 chapters."
+            )
 
     return [item.model_dump() for item in outline]
 

--- a/tests/test_editorial.py
+++ b/tests/test_editorial.py
@@ -328,7 +328,7 @@ def test_lint_flags_adjacent_technical_emergency_repetition() -> None:
     prior = ChapterDraft(
         chapter_number=1,
         title="Signal",
-        outline_summary="Mara discovers the patch.",
+        outline_summary="Mara discovers the patch. Mode: systems_crisis.",
         content=(
             "The lockdown slammed through the archive. An alarm cut over the speakers. "
             "A countdown opened above the console before Mara dragged the families into the shelter."
@@ -352,6 +352,7 @@ def test_lint_flags_adjacent_technical_emergency_repetition() -> None:
     assert result.needs_repair is True
     assert result.repair_scope == "targeted_scene_and_ending"
     assert any("adjacent chapter" in item.lower() for item in result.soft_warnings)
+    assert any("same scene mode" in item.lower() for item in result.soft_warnings)
 
 
 def test_lint_flags_system_crisis_without_human_visible_consequence() -> None:
@@ -378,21 +379,21 @@ def test_manuscript_quality_notes_tracks_repeated_emergency_mechanics() -> None:
         ChapterDraft(
             chapter_number=1,
             title="Signal",
-            outline_summary="Mara discovers the patch.",
+            outline_summary="Mara discovers the patch. Mode: systems_crisis.",
             content="A lockdown hit the vault. An alarm started while a countdown opened over the console.",
             status=ChapterStatus.COMPLETED,
         ),
         ChapterDraft(
             chapter_number=2,
             title="Watchdog",
-            outline_summary="Mara proves the patch is manipulating compliance.",
+            outline_summary="Mara proves the patch is manipulating compliance. Mode: systems_crisis.",
             content="The lockdown returned. A second alarm cut across the hatch as the countdown resumed.",
             status=ChapterStatus.COMPLETED,
         ),
         ChapterDraft(
             chapter_number=3,
             title="Source",
-            outline_summary="Mara finds the source.",
+            outline_summary="Mara finds the source. Mode: investigation.",
             content="Another alarm rang when the lockdown sealed the source chamber.",
             status=ChapterStatus.COMPLETED,
         ),
@@ -402,6 +403,8 @@ def test_manuscript_quality_notes_tracks_repeated_emergency_mechanics() -> None:
 
     assert any("Chapters 1-2 repeat emergency mechanics" in item for item in notes["technical_escalation_fatigue_findings"])
     assert any("Manuscript repeatedly returns" in item for item in notes["technical_escalation_fatigue_findings"])
+    assert any("Scene mode distribution" in item for item in notes["scene_mode_distribution_notes"])
+    assert any("repeat scene mode systems_crisis" in item for item in notes["scene_mode_distribution_notes"])
 
 
 def test_manuscript_lint_reports_meta_language_with_chapter_and_phrase() -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,6 +4,7 @@ from novel_generator.models import ChapterDraft, ChapterStatus, GenerationRun, P
 from novel_generator.services.prompts import (
     build_chapter_critique_messages,
     build_chapter_draft_messages,
+    build_chapter_plan_messages,
     build_chapter_revision_messages,
     build_story_bible_messages,
     parse_chapter_critique,
@@ -372,6 +373,99 @@ def test_outline_parser_requires_breather_or_aftermath_every_four_chapters() -> 
         raise AssertionError("Expected the outline parser to require a breather or aftermath chapter.")
 
 
+def test_outline_parser_rejects_chapter_mode_repeated_from_previous_two() -> None:
+    try:
+        parse_outline(
+            """
+            {
+              "chapters": [
+                {
+                  "chapter_number": 1,
+                  "act": "Act I",
+                  "title": "One",
+                  "objective": "One",
+                  "conflict_turn": "One",
+                  "character_turn": "One",
+                  "reveal": "One",
+                  "ending_state": "One",
+                  "outcome_type": "setback",
+                  "primary_obstacle": "One",
+                  "cost_if_success": "One",
+                  "side_character_friction": "One",
+                  "concrete_ending_hook": {"trigger": "One", "visible_object_or_actor": "One", "next_problem": "One"},
+                  "chapter_mode": "investigation",
+                  "civilian_life_detail": "One",
+                  "emotional_reveal": "One",
+                  "ideology_pressure": "One"
+                },
+                {
+                  "chapter_number": 2,
+                  "act": "Act I",
+                  "title": "Two",
+                  "objective": "Two",
+                  "conflict_turn": "Two",
+                  "character_turn": "Two",
+                  "reveal": "Two",
+                  "ending_state": "Two",
+                  "outcome_type": "reversal",
+                  "primary_obstacle": "Two",
+                  "cost_if_success": "Two",
+                  "side_character_friction": "Two",
+                  "concrete_ending_hook": {"trigger": "Two", "visible_object_or_actor": "Two", "next_problem": "Two"},
+                  "chapter_mode": "aftermath",
+                  "civilian_life_detail": "Two",
+                  "emotional_reveal": "Two",
+                  "ideology_pressure": "Two"
+                },
+                {
+                  "chapter_number": 3,
+                  "act": "Act II",
+                  "title": "Three",
+                  "objective": "Three",
+                  "conflict_turn": "Three",
+                  "character_turn": "Three",
+                  "reveal": "Three",
+                  "ending_state": "Three",
+                  "outcome_type": "setback",
+                  "primary_obstacle": "Three",
+                  "cost_if_success": "Three",
+                  "side_character_friction": "Three",
+                  "concrete_ending_hook": {"trigger": "Three", "visible_object_or_actor": "Three", "next_problem": "Three"},
+                  "chapter_mode": "investigation",
+                  "civilian_life_detail": "Three",
+                  "emotional_reveal": "Three",
+                  "ideology_pressure": "Three"
+                },
+                {
+                  "chapter_number": 4,
+                  "act": "Act II",
+                  "title": "Four",
+                  "objective": "Four",
+                  "conflict_turn": "Four",
+                  "character_turn": "Four",
+                  "reveal": "Four",
+                  "ending_state": "Four",
+                  "outcome_type": "setback",
+                  "primary_obstacle": "Four",
+                  "cost_if_success": "Four",
+                  "side_character_friction": "Four",
+                  "concrete_ending_hook": {"trigger": "Four", "visible_object_or_actor": "Four", "next_problem": "Four"},
+                  "chapter_mode": "public_debate",
+                  "civilian_life_detail": "Four",
+                  "emotional_reveal": "Four",
+                  "ideology_pressure": "Four"
+                }
+              ]
+            }
+            """,
+            requested_chapters=4,
+        )
+    except ValueError as exc:
+        assert "previous 2 chapters" in str(exc)
+    else:
+        raise AssertionError("Expected the outline parser to reject repeated recent chapter modes.")
+
+
 def test_chapter_plan_critique_and_continuity_parsers_accept_richer_shapes() -> None:
     plan = parse_chapter_plan(
         """
@@ -638,7 +732,7 @@ def test_prompt_builders_include_prose_voice_profile() -> None:
         "civilian_pressure_points": [],
         "emotional_open_loops": {},
         "side_character_decisions": {},
-        "genre_state": {},
+        "genre_state": {"recent_chapter_modes": "Chapter 1: investigation; Chapter 2: aftermath"},
     }
     critique = parse_chapter_critique(
         """
@@ -672,12 +766,16 @@ def test_prompt_builders_include_prose_voice_profile() -> None:
     )
 
     story_prompt = build_story_bible_messages(project, run)[1]["content"]
+    plan_prompt = build_chapter_plan_messages(project, run, chapter, outline_entry, story_bible, ledger, "No previous chapters.")[1]["content"]
     draft_prompt = build_chapter_draft_messages(project, run, chapter, outline_entry, story_bible, ledger, "No previous chapters.", plan)[1]["content"]
     critique_prompt = build_chapter_critique_messages(project, chapter, outline_entry, story_bible, ledger, plan, [])[1]["content"]
     revision_prompt = build_chapter_revision_messages(project, chapter, outline_entry, story_bible, ledger, plan, critique, [])[1]["content"]
 
     assert "Style targets: taut lyric pressure" in story_prompt
     assert '"style_profile"' in story_prompt
+    assert "Recent chapter modes to avoid repeating" in plan_prompt
+    assert "previous 2 chapters" in plan_prompt
+    assert "chapter_mode" in plan_prompt
     assert "Prose style profile" in draft_prompt
     assert "character_voice_map" in draft_prompt
     assert "final paragraph must include" in draft_prompt


### PR DESCRIPTION
## What changed

- Added a normalized allowed `chapter_mode` set and validation that prevents generated outlines from repeating the same mode used by either of the previous two chapters.
- Added `chapter_mode` to chapter plans, with recent mode history recorded in the continuity ledger so planning can avoid adjacent sameness.
- Extended deterministic lint to flag chapters whose claimed non-technical mode falls back into technical crisis mechanics, plus adjacent chapters that repeat both scene mode and crisis mechanics.
- Added manuscript QA scene-mode distribution notes and markdown output.
- Added focused tests for recent-mode outline validation, planning prompts, adjacent same-mode crisis repetition, and QA distribution reporting.

Fixes #16.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Could not run `python -m pytest tests/test_editorial.py tests/test_prompts.py` because this session has no `python` executable on PATH.