### PR TITLE
[codex] Require non-repeatable chapter story turns

### DIFF
--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -192,6 +192,9 @@ QUALITY_SIGNAL_DEFS = [
     {"field": "dialogue_tension_score", "label": "Dialogue tension", "lower_is_better": False, "default": 10},
     {"field": "repetition_risk_score", "label": "Repetition risk", "lower_is_better": True},
     {"field": "technical_escalation_fatigue_score", "label": "Technical fatigue", "lower_is_better": True},
+    {"field": "irreversibility_score", "label": "Irreversibility", "lower_is_better": False, "default": 10},
+    {"field": "choice_clarity_score", "label": "Choice clarity", "lower_is_better": False, "default": 10},
+    {"field": "cuttable_chapter_risk_score", "label": "Cuttable risk", "lower_is_better": True},
 ]
 COMPARISON_CATEGORY_DEFS = [
     {
@@ -225,6 +228,14 @@ COMPARISON_CATEGORY_DEFS = [
         "threshold": 6,
         "mode": "high",
         "keywords": ["repetition", "repeated", "stock phrase"],
+    },
+    {
+        "id": "story_turn",
+        "label": "Story-turn risks",
+        "field": "cuttable_chapter_risk_score",
+        "threshold": 6,
+        "mode": "high",
+        "keywords": ["story turn", "cuttable", "irreversible"],
     },
     {
         "id": "emotional",

--- a/src/novel_generator/schemas.py
+++ b/src/novel_generator/schemas.py
@@ -315,6 +315,36 @@ class ContinuityLedger(BaseModel):
         return _clean_list_map(value)
 
 
+class ChapterStoryTurn(BaseModel):
+    irreversible_change: str = ""
+    protagonist_choice: str = ""
+    choice_alternatives: list[str] = Field(default_factory=list)
+    permanent_consequence: str = ""
+    why_this_chapter_cannot_be_cut: str = ""
+    state_before: str = ""
+    state_after: str = ""
+
+    @field_validator("choice_alternatives", mode="before")
+    @classmethod
+    def validate_choice_alternatives(cls, value: Any) -> list[str]:
+        return _clean_list(value)
+
+    @field_validator(
+        "irreversible_change",
+        "protagonist_choice",
+        "permanent_consequence",
+        "why_this_chapter_cannot_be_cut",
+        "state_before",
+        "state_after",
+        mode="before",
+    )
+    @classmethod
+    def validate_story_turn_strings(cls, value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+
 class ChapterPlan(BaseModel):
     chapter_mode: str = ""
     opening_state: str
@@ -334,6 +364,7 @@ class ChapterPlan(BaseModel):
     independent_side_character_move: str = ""
     genre_specific_focus: str = ""
     genre_specific_beats: list[str] = Field(default_factory=list)
+    story_turn: "ChapterStoryTurn" = Field(default_factory=lambda: ChapterStoryTurn())
 
     @field_validator("scene_beats", "genre_specific_beats", mode="before")
     @classmethod
@@ -365,6 +396,7 @@ class ChapterContinuityUpdate(BaseModel):
     civilian_pressure_points: list[str] = Field(default_factory=list)
     emotional_open_loops: dict[str, str] = Field(default_factory=dict)
     side_character_decisions: dict[str, list[str]] = Field(default_factory=dict)
+    story_turn: "ChapterStoryTurn" = Field(default_factory=lambda: ChapterStoryTurn())
     genre_state: dict[str, str] = Field(default_factory=dict)
 
     @field_validator(
@@ -407,6 +439,9 @@ class ChapterCritique(BaseModel):
     sensory_specificity_score: int = Field(default=10, ge=0, le=10)
     dialogue_tension_score: int = Field(default=10, ge=0, le=10)
     technical_escalation_fatigue_score: int = Field(default=0, ge=0, le=10)
+    irreversibility_score: int = Field(default=10, ge=0, le=10)
+    choice_clarity_score: int = Field(default=10, ge=0, le=10)
+    cuttable_chapter_risk_score: int = Field(default=0, ge=0, le=10)
     blocking_issues: list[str] = Field(default_factory=list)
     soft_warnings: list[str] = Field(default_factory=list)
     genre_contract_findings: list[str] = Field(default_factory=list)
@@ -443,6 +478,9 @@ class ChapterCritique(BaseModel):
         "sensory_specificity_score",
         "dialogue_tension_score",
         "technical_escalation_fatigue_score",
+        "irreversibility_score",
+        "choice_clarity_score",
+        "cuttable_chapter_risk_score",
         mode="before",
     )
     @classmethod
@@ -495,6 +533,7 @@ class ManuscriptQaReport(BaseModel):
     civilian_texture_findings: list[str] = Field(default_factory=list)
     technical_escalation_fatigue_findings: list[str] = Field(default_factory=list)
     scene_mode_distribution_notes: list[str] = Field(default_factory=list)
+    story_turn_quality_notes: list[str] = Field(default_factory=list)
     genre_contract_notes: list[str] = Field(default_factory=list)
 
     @field_validator("overall_verdict", mode="before")
@@ -520,6 +559,7 @@ class ManuscriptQaReport(BaseModel):
         "civilian_texture_findings",
         "technical_escalation_fatigue_findings",
         "scene_mode_distribution_notes",
+        "story_turn_quality_notes",
         "genre_contract_notes",
         mode="before",
     )

--- a/src/novel_generator/services/editorial.py
+++ b/src/novel_generator/services/editorial.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import Counter
 from dataclasses import dataclass, field
+import json
 import re
 from typing import Any
 
@@ -30,6 +31,25 @@ STOCK_PHRASES = [
 BREATHER_MODES = {"breather", "aftermath"}
 
 TECHNICAL_SCENE_MODES = {"systems_crisis", "technical_operation"}
+
+STORY_TURN_REQUIRED_FIELDS = (
+    "irreversible_change",
+    "protagonist_choice",
+    "permanent_consequence",
+    "why_this_chapter_cannot_be_cut",
+    "state_before",
+    "state_after",
+)
+
+ABSTRACT_STORY_TURN_PATTERNS = [
+    r"\bstakes? (?:rise|increase|escalate)\b",
+    r"\bthe story (?:moves|pushes|continues|goes) forward\b",
+    r"\bthings? (?:change|changed)\b",
+    r"\beverything (?:changes|changed)\b",
+    r"\bthe next problem\b",
+    r"\bthe future\b",
+    r"\bthe choice (?:is|was) clear\b",
+]
 
 ABSTRACT_ENDING_PATTERNS = [
     r"\bnext problem\b",
@@ -845,6 +865,94 @@ def _meta_language_hits(text: str) -> list[str]:
     return list(dict.fromkeys(hits))
 
 
+def _coerce_story_turn(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if value is None:
+        return {}
+    return getattr(value, "model_dump", lambda: {})()
+
+
+def _story_turn_from_plan(chapter_plan: dict[str, Any]) -> dict[str, Any]:
+    return _coerce_story_turn(chapter_plan.get("story_turn"))
+
+
+def _story_turn_from_chapter(chapter: ChapterDraft) -> dict[str, Any]:
+    continuity_update = chapter.continuity_update or {}
+    if not isinstance(continuity_update, dict):
+        continuity_update = getattr(continuity_update, "model_dump", lambda: {})()
+    continuity_turn = _coerce_story_turn(continuity_update.get("story_turn"))
+    if continuity_turn:
+        return continuity_turn
+    plan_text = (chapter.plan or "").strip()
+    if not plan_text:
+        return {}
+    try:
+        plan_payload = json.loads(plan_text)
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(plan_payload, dict):
+        return {}
+    return _coerce_story_turn(plan_payload.get("story_turn"))
+
+
+def _story_turn_text(story_turn: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for field_name in STORY_TURN_REQUIRED_FIELDS:
+        parts.append(str(story_turn.get(field_name, "")))
+    parts.extend(str(item) for item in story_turn.get("choice_alternatives", []) or [])
+    return " ".join(part for part in parts if part).strip()
+
+
+def _missing_story_turn_fields(story_turn: dict[str, Any]) -> list[str]:
+    missing = [
+        field_name
+        for field_name in STORY_TURN_REQUIRED_FIELDS
+        if not str(story_turn.get(field_name, "")).strip()
+    ]
+    if not _clean_story_turn_alternatives(story_turn):
+        missing.append("choice_alternatives")
+    return missing
+
+
+def _clean_story_turn_alternatives(story_turn: dict[str, Any]) -> list[str]:
+    return [
+        str(item).strip()
+        for item in story_turn.get("choice_alternatives", []) or []
+        if str(item).strip()
+    ]
+
+
+def _abstract_story_turn_hits(story_turn: dict[str, Any]) -> list[str]:
+    text = _story_turn_text(story_turn)
+    hits: list[str] = []
+    for pattern in ABSTRACT_STORY_TURN_PATTERNS:
+        for match in re.finditer(pattern, text, flags=re.IGNORECASE):
+            hits.append(match.group(0).strip())
+    return list(dict.fromkeys(hits))
+
+
+def _story_turn_terms(story_turn: dict[str, Any]) -> set[str]:
+    text = " ".join(
+        str(story_turn.get(field_name, ""))
+        for field_name in (
+            "irreversible_change",
+            "protagonist_choice",
+            "permanent_consequence",
+            "state_after",
+        )
+    )
+    return _meaningful_terms(text)
+
+
+def _story_turn_similarity(first: dict[str, Any], second: dict[str, Any]) -> float:
+    first_terms = _story_turn_terms(first)
+    second_terms = _story_turn_terms(second)
+    if not first_terms or not second_terms:
+        return 0
+    return len(first_terms & second_terms) / max(1, min(len(first_terms), len(second_terms)))
+
+
 def detect_canonical_entity_collisions(
     existing_entities: list[CanonicalEntity | dict[str, Any]],
     new_entities: list[CanonicalEntity | dict[str, Any]],
@@ -924,6 +1032,36 @@ def lint_chapter(
         )
         result.needs_repair = True
         result.repair_scope = "targeted_scene_and_ending"
+
+    story_turn = _story_turn_from_plan(chapter_plan)
+    missing_story_turn_fields = _missing_story_turn_fields(story_turn)
+    if missing_story_turn_fields:
+        result.blocking_issues.append(
+            f"Chapter {chapter.chapter_number} is missing required story_turn fields: "
+            + ", ".join(missing_story_turn_fields)
+            + "."
+        )
+        result.needs_repair = True
+        result.repair_scope = "targeted_scene_and_ending"
+    else:
+        abstract_hits = _abstract_story_turn_hits(story_turn)
+        if abstract_hits:
+            result.blocking_issues.append(
+                f"Chapter {chapter.chapter_number} has an abstract or reversible story_turn: "
+                + ", ".join(f"'{hit}'" for hit in abstract_hits[:5])
+                + "."
+            )
+            result.needs_repair = True
+            result.repair_scope = "targeted_scene_and_ending"
+        for previous in prior_chapters:
+            previous_turn = _story_turn_from_chapter(previous)
+            if previous_turn and _story_turn_similarity(story_turn, previous_turn) >= 0.75:
+                result.soft_warnings.append(
+                    f"Chapter {chapter.chapter_number} repeats a similar irreversible story turn from chapter {previous.chapter_number}."
+                )
+                result.needs_repair = True
+                result.repair_scope = "targeted_scene_and_ending"
+                break
 
     ending_text = _ending_text(content)
     final_beat = _final_beat_text(content)
@@ -1338,6 +1476,7 @@ def manuscript_quality_notes(
         "civilian_texture_findings": [],
         "technical_escalation_fatigue_findings": [],
         "scene_mode_distribution_notes": [],
+        "story_turn_quality_notes": [],
         "genre_contract_notes": [],
     }
 
@@ -1387,10 +1526,36 @@ def manuscript_quality_notes(
             notes["technical_escalation_fatigue_findings"].append(
                 f"Chapter {chapter.chapter_number} may be too dense with emergency-system language."
             )
+        if (
+            qa.get("irreversibility_score", 10) <= 5
+            or qa.get("choice_clarity_score", 10) <= 5
+            or qa.get("cuttable_chapter_risk_score", 0) >= 6
+            or "story turn" in lowered_warnings
+            or "cuttable" in lowered_warnings
+        ):
+            notes["story_turn_quality_notes"].append(
+                f"Chapter {chapter.chapter_number} may need a stronger irreversible choice/consequence turn."
+            )
         if qa.get("genre_contract_score", 10) <= 5 or "genre" in lowered_warnings:
             notes["genre_contract_notes"].append(
                 f"Chapter {chapter.chapter_number} may need stronger delivery against the selected genre contract."
             )
+        story_turn = _story_turn_from_chapter(chapter)
+        missing_fields = _missing_story_turn_fields(story_turn)
+        if missing_fields:
+            notes["story_turn_quality_notes"].append(
+                f"Chapter {chapter.chapter_number} is missing stored story_turn fields: "
+                + ", ".join(missing_fields)
+                + "."
+            )
+        else:
+            abstract_hits = _abstract_story_turn_hits(story_turn)
+            if abstract_hits:
+                notes["story_turn_quality_notes"].append(
+                    f"Chapter {chapter.chapter_number} has an abstract or reversible stored story_turn: "
+                    + ", ".join(f"'{hit}'" for hit in abstract_hits[:5])
+                    + "."
+                )
         for item in qa.get("genre_contract_findings", []) or []:
             notes["genre_contract_notes"].append(f"Chapter {chapter.chapter_number}: {item}")
         for phrase in STOCK_PHRASES:
@@ -1430,6 +1595,12 @@ def manuscript_quality_notes(
                 notes["scene_mode_distribution_notes"].append(
                     f"Chapters {previous.chapter_number}-{current.chapter_number} repeat scene mode {current_mode}; consider varying the dominant dramatic mode."
                 )
+        previous_turn = _story_turn_from_chapter(previous)
+        current_turn = _story_turn_from_chapter(current)
+        if previous_turn and current_turn and _story_turn_similarity(previous_turn, current_turn) >= 0.75:
+            notes["story_turn_quality_notes"].append(
+                f"Chapters {previous.chapter_number}-{current.chapter_number} have equivalent irreversible story turns; consider merge, cut, or a replacement choice/consequence."
+            )
 
     chapter_modes = [
         _chapter_mode_from_summary(chapter.outline_summary or "")
@@ -1516,6 +1687,7 @@ def manuscript_quality_notes(
     notes["civilian_texture_findings"] = list(dict.fromkeys(notes["civilian_texture_findings"]))
     notes["technical_escalation_fatigue_findings"] = list(dict.fromkeys(notes["technical_escalation_fatigue_findings"]))
     notes["scene_mode_distribution_notes"] = list(dict.fromkeys(notes["scene_mode_distribution_notes"]))
+    notes["story_turn_quality_notes"] = list(dict.fromkeys(notes["story_turn_quality_notes"]))
     notes["genre_contract_notes"] = list(dict.fromkeys(notes["genre_contract_notes"]))
     return notes
 
@@ -1585,6 +1757,10 @@ def render_qa_report_markdown(report: ManuscriptQaReport) -> str:
         "## Scene Mode Distribution",
         "",
         *([f"- {item}" for item in report.scene_mode_distribution_notes] or ["- No scene-mode distribution notes recorded."]),
+        "",
+        "## Story Turn Quality",
+        "",
+        *([f"- {item}" for item in report.story_turn_quality_notes] or ["- No story-turn quality notes recorded."]),
         "",
         "## Genre Contract",
         "",

--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -356,6 +356,8 @@ ENDING_REPAIR_TYPES = {"abstract_cliffhanger", "image_or_feeling_beat", "outline
 ENDING_REPAIR_THRESHOLD = 5
 TECHNICAL_FATIGUE_REPAIR_THRESHOLD = 6
 SIDE_CHARACTER_REPAIR_THRESHOLD = 5
+STORY_TURN_REPAIR_THRESHOLD = 5
+CUTTABLE_CHAPTER_REPAIR_THRESHOLD = 6
 
 
 def _ending_score_warnings(critique: ChapterCritique) -> list[str]:
@@ -391,11 +393,32 @@ def _side_character_warnings(critique: ChapterCritique) -> list[str]:
     ]
 
 
+def _story_turn_warnings(critique: ChapterCritique) -> list[str]:
+    warnings: list[str] = []
+    if critique.irreversibility_score <= STORY_TURN_REPAIR_THRESHOLD:
+        warnings.append(
+            "Story turn needs a stronger irreversible change: "
+            f"irreversibility {critique.irreversibility_score}/10."
+        )
+    if critique.choice_clarity_score <= STORY_TURN_REPAIR_THRESHOLD:
+        warnings.append(
+            "Story turn needs a clearer protagonist choice: "
+            f"choice clarity {critique.choice_clarity_score}/10."
+        )
+    if critique.cuttable_chapter_risk_score >= CUTTABLE_CHAPTER_REPAIR_THRESHOLD:
+        warnings.append(
+            "Chapter may be cuttable without damaging manuscript state: "
+            f"cuttable risk {critique.cuttable_chapter_risk_score}/10."
+        )
+    return warnings
+
+
 def _combine_chapter_feedback(critique: ChapterCritique, lint_result: ChapterLintResult) -> ChapterCritique:
     style_warnings = _style_score_warnings(critique)
     ending_warnings = _ending_score_warnings(critique)
     technical_warnings = _technical_fatigue_warnings(critique)
     side_character_warnings = _side_character_warnings(critique)
+    story_turn_warnings = _story_turn_warnings(critique)
     blocking_issues = _dedupe([*critique.blocking_issues, *lint_result.blocking_issues])
     soft_warnings = _dedupe(
         [
@@ -405,6 +428,7 @@ def _combine_chapter_feedback(critique: ChapterCritique, lint_result: ChapterLin
             *ending_warnings,
             *technical_warnings,
             *side_character_warnings,
+            *story_turn_warnings,
         ]
     )
     warnings = _dedupe([*critique.warnings, *soft_warnings])
@@ -417,6 +441,7 @@ def _combine_chapter_feedback(critique: ChapterCritique, lint_result: ChapterLin
         or bool(ending_warnings)
         or bool(technical_warnings)
         or bool(side_character_warnings)
+        or bool(story_turn_warnings)
     )
     repair_scope = _resolve_repair_scope(
         critique.repair_scope,
@@ -424,6 +449,7 @@ def _combine_chapter_feedback(critique: ChapterCritique, lint_result: ChapterLin
         "targeted_scene_and_ending" if ending_warnings else "none",
         "targeted_scene_and_ending" if technical_warnings else "none",
         "targeted_scene_and_ending" if side_character_warnings else "none",
+        "targeted_scene_and_ending" if story_turn_warnings else "none",
         "voice_and_texture" if style_warnings else "none",
     )
     return critique.model_copy(
@@ -811,6 +837,12 @@ def _run_manuscript_qa(
                 [
                     *qa_report.scene_mode_distribution_notes,
                     *deterministic_notes["scene_mode_distribution_notes"],
+                ]
+            ),
+            "story_turn_quality_notes": _dedupe(
+                [
+                    *qa_report.story_turn_quality_notes,
+                    *deterministic_notes["story_turn_quality_notes"],
                 ]
             ),
             "genre_contract_notes": _dedupe(

--- a/src/novel_generator/services/prompts.py
+++ b/src/novel_generator/services/prompts.py
@@ -55,6 +55,13 @@ def _genre_profile_block(profile: GenreProfile) -> str:
     return json.dumps(_genre_profile_payload(profile), indent=2)
 
 
+def _chapter_continuity_payload(chapter: ChapterDraft) -> dict[str, Any]:
+    payload = chapter.continuity_update or {}
+    if isinstance(payload, dict):
+        return payload
+    return getattr(payload, "model_dump", lambda: {})()
+
+
 def _story_brief_lines(project: Project) -> str:
     brief = project.story_brief or {}
     profile = genre_profile(brief.get("genre_profile"))
@@ -408,7 +415,16 @@ def build_chapter_plan_messages(
                 '  "primary_interpersonal_conflict": "string",\n'
                 '  "independent_side_character_move": "string",\n'
                 '  "genre_specific_focus": "string",\n'
-                '  "genre_specific_beats": ["profile-specific beat 1", "profile-specific beat 2"]\n'
+                '  "genre_specific_beats": ["profile-specific beat 1", "profile-specific beat 2"],\n'
+                '  "story_turn": {\n'
+                '    "irreversible_change": "string",\n'
+                '    "protagonist_choice": "string",\n'
+                '    "choice_alternatives": ["credible path not taken"],\n'
+                '    "permanent_consequence": "string",\n'
+                '    "why_this_chapter_cannot_be_cut": "string",\n'
+                '    "state_before": "string",\n'
+                '    "state_after": "string"\n'
+                "  }\n"
                 "}\n\n"
                 "Rules:\n"
                 f"- use only these chapter_mode values: {chapter_mode_options}\n"
@@ -416,6 +432,10 @@ def build_chapter_plan_messages(
                 "- chapter_mode must describe the dominant dramatic mode of the planned scene, not the presence of a console, alarm, drone, or system prop\n"
                 "- include 4 to 6 concrete scene beats\n"
                 "- at least one beat must materially worsen or transform the conflict\n"
+                "- define story_turn before drafting; it must name what permanently changes, what the protagonist chooses, what credible alternatives they rejected, and what consequence cannot be undone\n"
+                "- story_turn.why_this_chapter_cannot_be_cut must explain the structural damage caused if the chapter were removed, not just say it advances the plot\n"
+                "- story_turn.state_before and story_turn.state_after must differ in concrete plot state, leverage, relationship, public consequence, system state, or belief position\n"
+                "- do not use generic story_turn language such as 'stakes rise', 'the story moves forward', 'things change', or 'the next problem becomes clear'\n"
                 "- if the protagonist uses a technical solution, the plan must include a visible cost or exposure\n"
                 "- side characters must exert pressure from their own agendas, not merely help or warn\n"
                 "- independent_side_character_move must name what a non-protagonist does on purpose to change the plot, not just what they say or explain\n"
@@ -477,6 +497,8 @@ def build_chapter_draft_messages(
                 "- do not include a chapter heading or title line\n"
                 "- do not repeat the inciting incident unless the situation has materially changed\n"
                 "- the chapter must change the external situation and at least one character state\n"
+                "- enact chapter_plan.story_turn on the page: the irreversible_change, protagonist_choice, rejected alternatives, permanent_consequence, and state_after must be visible in scene action or dialogue\n"
+                "- do not substitute repeated technical activity for the unique choice/consequence promised by chapter_plan.story_turn\n"
                 "- if a technical solution works, show the concrete cost, fallout, or exposure on the page\n"
                 "- use at most one primary system-crisis mechanic; avoid stacking lockdown, quarantine, reboot, alarm, warning banner, reserve drain, core temperature, critical failure, drone breach, override, and countdown beats in the same chapter\n"
                 "- when technical pressure appears, translate it into human-visible consequences: changed options, endangered civilians, fractured trust, physical danger, political constraint, or emotional cost\n"
@@ -570,6 +592,9 @@ def build_chapter_critique_messages(
                 '  "sensory_specificity_score": 0,\n'
                 '  "dialogue_tension_score": 0,\n'
                 '  "technical_escalation_fatigue_score": 0,\n'
+                '  "irreversibility_score": 0,\n'
+                '  "choice_clarity_score": 0,\n'
+                '  "cuttable_chapter_risk_score": 0,\n'
                 '  "blocking_issues": ["string"],\n'
                 '  "soft_warnings": ["string"],\n'
                 '  "genre_contract_findings": ["string"],\n'
@@ -579,6 +604,7 @@ def build_chapter_critique_messages(
                 "- classify ending_hook_type as concrete_action_hook when the final beat is a visible event/action/reversal, resolved_scene_turn when it quietly completes the scene turn with a tangible decision or state change, abstract_cliffhanger when it only gestures at future stakes, image_or_feeling_beat when it ends on mood/image without external consequence, or outline_summary when it uses planning language such as 'next problem' or 'next step'\n"
                 "- set revision_required to true if any draft prose contains meta/outlining language such as 'The chapter ends on', 'This lays the groundwork for', 'pushing the story forward', 'The story was not finished', 'the decision would shape the next chapter', or 'in the next chapter'\n"
                 "- set revision_required to true if the chapter has an abstract ending, outline-summary ending, image/feeling-only ending, unresolved immediate scene turn, zero-cost major solution, repeated emergency mechanics, repeated premise beat, side character who only helps or warns, proper-noun inconsistency, emotional fallout that disappears, blurred ideology positions, or weak style/voice delivery\n"
+                "- set revision_required to true if the chapter lacks the planned irreversible story_turn, if protagonist_choice is unclear, if the permanent_consequence is reversible or abstract, or if the chapter could be cut without changing the manuscript state\n"
                 "- use repair_scope 'voice_and_texture' when the main problem is flat prose, samey dialogue, repeated sentence rhythm, weak sensory specificity, or poor style-profile alignment\n"
                 "- use repair_scope 'targeted_scene_and_ending' for ending, cost, repetition-fatigue, or side-character pressure problems\n"
                 "- use repair_scope 'full_chapter' only when continuity or premise repetition is severe\n"
@@ -594,6 +620,9 @@ def build_chapter_critique_messages(
                 "- set revision_required to true if any style score is 5 or lower\n"
                 "- technical_escalation_fatigue_score should be higher when the chapter stacks or repeats lockdowns, quarantines, reboots, alarms, warning banners, reserve percentages, core temperature spikes, critical failures, drone breaches, overrides, or countdowns\n"
                 "- set revision_required to true if technical_escalation_fatigue_score is 6 or higher, especially when the technical stakes are not translated into interpersonal, political, physical, civilian, or emotional consequences\n"
+                "- irreversibility_score and choice_clarity_score should be higher when the story_turn is concrete, visible, and decision-driven\n"
+                "- cuttable_chapter_risk_score should be higher when the chapter can be removed or reordered without damaging plot state, character state, leverage, or consequence\n"
+                "- set revision_required to true if irreversibility_score or choice_clarity_score is 5 or lower, or if cuttable_chapter_risk_score is 6 or higher\n"
                 "- genre_contract_findings must call out any missing or especially strong profile-specific expectations\n"
                 "- include profile-specific lint focus: "
                 + "; ".join(profile.lint_focus)
@@ -646,6 +675,8 @@ def build_chapter_revision_messages(
                 "- if repair_scope is 'targeted_scene_and_ending', preserve the good material and rewrite only the weakest scene plus the final 2 to 3 paragraphs\n"
                 "- if repair_scope is 'full_chapter', rebuild the chapter so it stops repeating the premise and restores continuity\n"
                 "- if ending_hook_type is abstract_cliffhanger, image_or_feeling_beat, or outline_summary, replace the final beat with a concrete external action, visible consequence, irreversible decision, reveal, reversal, or state change\n"
+                "- if the chapter lacks a strong story_turn, replace repeated technical activity with one unique protagonist choice and one permanent consequence that makes the chapter non-cuttable\n"
+                "- make the revised chapter deliver chapter_plan.story_turn, especially irreversible_change, protagonist_choice, permanent_consequence, why_this_chapter_cannot_be_cut, state_before, and state_after\n"
                 "- make the revised ending resolve the chapter's immediate scene tension while opening the next problem through something visible on the page\n"
                 "- remove meta/outlining language such as 'The chapter ends on', 'This lays the groundwork for', 'The next problem', 'pushing the story forward', 'The story was not finished', 'the decision would shape the next chapter', or 'in the next chapter' while preserving the actual scene event\n"
                 "- do not end with planning-language such as 'the next problem', 'the next step', 'the choice ahead', or equivalent outline-summary language\n"
@@ -748,6 +779,15 @@ def build_continuity_update_messages(
                 '  "civilian_pressure_points": ["concrete civilian consequence"],\n'
                 '  "emotional_open_loops": {"Character": "unresolved emotional burden"},\n'
                 '  "side_character_decisions": {"Character": ["independent action that changed the plot"]},\n'
+                '  "story_turn": {\n'
+                '    "irreversible_change": "what permanently changed in this completed chapter",\n'
+                '    "protagonist_choice": "what the protagonist chose on the page",\n'
+                '    "choice_alternatives": ["credible alternative not chosen"],\n'
+                '    "permanent_consequence": "consequence that cannot simply be undone next chapter",\n'
+                '    "why_this_chapter_cannot_be_cut": "specific state, leverage, relationship, or consequence the manuscript loses if cut",\n'
+                '    "state_before": "concrete state before the chapter",\n'
+                '    "state_after": "concrete state after the chapter"\n'
+                "  },\n"
                 '  "genre_state": {"profile state key": "current state after this chapter"}\n'
                 "}\n\n"
                 "Rules:\n"
@@ -759,6 +799,7 @@ def build_continuity_update_messages(
                 "- if a character's belief is contradicted, mark whether that contradiction is intentional in ideology_shift_notes\n"
                 "- preserve memory damage, trust fractures, civilian harm, and unresolved emotional fallout unless the chapter truly heals them\n"
                 "- track major side-character decisions when a non-protagonist takes an independent action that changes the protagonist's options\n"
+                "- story_turn must summarize the actual irreversible change, protagonist choice, rejected alternatives, permanent consequence, and before/after manuscript state created by this chapter\n"
                 "- update genre_state using the selected profile's continuity focus and default_genre_state\n"
                 "- include profile-specific continuity focus: "
                 + "; ".join(profile.continuity_focus)
@@ -781,6 +822,7 @@ def build_manuscript_qa_messages(
             "title": chapter.title,
             "summary": chapter.summary or "",
             "word_count": chapter.word_count,
+            "story_turn": _chapter_continuity_payload(chapter).get("story_turn", {}),
             "qa_notes": chapter.qa_notes or {},
         }
         for chapter in chapters
@@ -819,10 +861,11 @@ def build_manuscript_qa_messages(
                 '  "civilian_texture_findings": ["string"],\n'
                 '  "technical_escalation_fatigue_findings": ["string"],\n'
                 '  "scene_mode_distribution_notes": ["string"],\n'
+                '  "story_turn_quality_notes": ["string"],\n'
                 '  "genre_contract_notes": ["string"]\n'
                 "}\n\n"
                 "Be specific about repeated setups, duplicated endings, abstract or outline-summary endings, continuity instability, easy technical wins, side-character flatness, "
-                "meta/outlining language in chapter prose, chapter_mode distribution and adjacent mode repetition, proper-noun drift, emotional pacing, ideology blur, civilian-life absence, repeated emergency mechanics such as lockdown, quarantine, reboot, alarm, warning banner, reserve drain, core temperature, critical failure, drone breach, override, or countdown, and whether the manuscript delivers on the ending promise. "
+                "meta/outlining language in chapter prose, chapter_mode distribution and adjacent mode repetition, story_turn quality, cuttable chapters, duplicated irreversible turns, proper-noun drift, emotional pacing, ideology blur, civilian-life absence, repeated emergency mechanics such as lockdown, quarantine, reboot, alarm, warning banner, reserve drain, core temperature, critical failure, drone breach, override, or countdown, and whether the manuscript delivers on the ending promise. "
                 "Genre contract notes must judge the selected profile: "
                 + "; ".join(profile.qa_focus or profile.genre_contract)
             ),
@@ -1010,7 +1053,25 @@ def parse_chapter_plan(text: str) -> ChapterPlan:
     payload = extract_json_payload(text)
     if isinstance(payload, dict) and "plan" in payload:
         payload = payload["plan"]
-    return ChapterPlan.model_validate(payload)
+    plan = ChapterPlan.model_validate(payload)
+    required_story_turn_fields = [
+        "irreversible_change",
+        "protagonist_choice",
+        "permanent_consequence",
+        "why_this_chapter_cannot_be_cut",
+        "state_before",
+        "state_after",
+    ]
+    missing_fields = [
+        field_name
+        for field_name in required_story_turn_fields
+        if not getattr(plan.story_turn, field_name).strip()
+    ]
+    if not plan.story_turn.choice_alternatives:
+        missing_fields.append("choice_alternatives")
+    if missing_fields:
+        raise ValueError("Chapter plan must include a complete story_turn: " + ", ".join(missing_fields) + ".")
+    return plan
 
 
 def parse_chapter_critique(text: str) -> ChapterCritique:

--- a/src/novel_generator/static/ui.js
+++ b/src/novel_generator/static/ui.js
@@ -365,6 +365,9 @@ function setupRunDetail() {
     { field: "dialogue_tension_score", label: "Dialogue tension", lowerIsBetter: false, defaultScore: 10 },
     { field: "repetition_risk_score", label: "Repetition risk", lowerIsBetter: true },
     { field: "technical_escalation_fatigue_score", label: "Technical fatigue", lowerIsBetter: true },
+    { field: "irreversibility_score", label: "Irreversibility", lowerIsBetter: false, defaultScore: 10 },
+    { field: "choice_clarity_score", label: "Choice clarity", lowerIsBetter: false, defaultScore: 10 },
+    { field: "cuttable_chapter_risk_score", label: "Cuttable risk", lowerIsBetter: true },
   ];
   const terminalStatuses = new Set(["completed", "failed", "canceled"]);
   const reviewStatuses = new Set(["awaiting_approval"]);

--- a/src/novel_generator/templates/run_detail.html
+++ b/src/novel_generator/templates/run_detail.html
@@ -918,6 +918,9 @@
                       <li>Sensory specificity: {{ chapter.qa_notes.sensory_specificity_score|default(10) }}/10</li>
                       <li>Dialogue tension: {{ chapter.qa_notes.dialogue_tension_score|default(10) }}/10</li>
                       <li>Technical fatigue: {{ chapter.qa_notes.technical_escalation_fatigue_score|default(0) }}/10</li>
+                      <li>Irreversibility: {{ chapter.qa_notes.irreversibility_score|default(10) }}/10</li>
+                      <li>Choice clarity: {{ chapter.qa_notes.choice_clarity_score|default(10) }}/10</li>
+                      <li>Cuttable risk: {{ chapter.qa_notes.cuttable_chapter_risk_score|default(0) }}/10</li>
                     </ul>
                   </div>
                   {% if chapter.qa_notes.strengths %}

--- a/tests/test_editorial.py
+++ b/tests/test_editorial.py
@@ -101,6 +101,15 @@ def _plan() -> dict:
         "ideology_clash": "Nadia argues that truth without shelter is just another cruelty.",
         "primary_interpersonal_conflict": "Nadia refuses to keep enabling Mara's collateral damage.",
         "independent_side_character_move": "Nadia refuses to falsify the archive to protect Mara.",
+        "story_turn": {
+            "irreversible_change": "Nadia's archive credentials are burned and the source node becomes Mara's only lead.",
+            "protagonist_choice": "Mara chooses to expose the audit trail even though it burns Nadia's access.",
+            "choice_alternatives": ["Mara could abandon the logs to protect Nadia's credentials."],
+            "permanent_consequence": "Nadia loses archive access and her trust in Mara fractures.",
+            "why_this_chapter_cannot_be_cut": "Without this turn, Mara never loses Nadia's trust or narrows the chase to the source node.",
+            "state_before": "Mara and Nadia can still use the archive quietly.",
+            "state_after": "Nadia is locked out and Mara has one dangerous source node to chase.",
+        },
     }
 
 
@@ -160,6 +169,36 @@ def test_chapter_lint_flags_outline_summary_ending_language() -> None:
     assert result.needs_repair is True
     assert result.repair_scope == "targeted_scene_and_ending"
     assert any("outline-summary language" in item.lower() for item in result.blocking_issues)
+
+
+def test_chapter_lint_flags_abstract_story_turn() -> None:
+    chapter = ChapterDraft(
+        chapter_number=2,
+        title="Watchdog",
+        outline_summary="Mara proves the patch is manipulating compliance.",
+        content=(
+            "Mara got the logs open while Nadia braced the archive hatch. "
+            "A drone stopped outside the hatch. Its lens turned blue. It spoke in Nadia's voice."
+        ),
+        status=ChapterStatus.PENDING,
+    )
+    weak_plan = {
+        **_plan(),
+        "story_turn": {
+            "irreversible_change": "The stakes rise and everything changes.",
+            "protagonist_choice": "Mara keeps going because the choice is clear.",
+            "choice_alternatives": ["Mara could stop."],
+            "permanent_consequence": "The future is different.",
+            "why_this_chapter_cannot_be_cut": "The story moves forward.",
+            "state_before": "There is a problem.",
+            "state_after": "The next problem becomes clear.",
+        },
+    }
+
+    result = lint_chapter(chapter, _outline_entry(), weak_plan, _story_bible(), _ledger(), [])
+
+    assert result.needs_repair is True
+    assert any("abstract or reversible story_turn" in item for item in result.blocking_issues)
 
 
 def test_chapter_lint_flags_meta_language_variants_anywhere_in_prose() -> None:
@@ -405,6 +444,42 @@ def test_manuscript_quality_notes_tracks_repeated_emergency_mechanics() -> None:
     assert any("Manuscript repeatedly returns" in item for item in notes["technical_escalation_fatigue_findings"])
     assert any("Scene mode distribution" in item for item in notes["scene_mode_distribution_notes"])
     assert any("repeat scene mode systems_crisis" in item for item in notes["scene_mode_distribution_notes"])
+
+
+def test_manuscript_quality_notes_flags_equivalent_story_turns() -> None:
+    story_turn = {
+        "irreversible_change": "Mara burns Nadia's archive access to expose the source node.",
+        "protagonist_choice": "Mara chooses proof over Nadia's credentials.",
+        "choice_alternatives": ["Mara could protect Nadia and abandon the source logs."],
+        "permanent_consequence": "Nadia is locked out and no longer trusts Mara.",
+        "why_this_chapter_cannot_be_cut": "The manuscript needs Nadia locked out and mistrustful.",
+        "state_before": "Mara and Nadia can still use the archive.",
+        "state_after": "Nadia is locked out and Mara has the source node.",
+    }
+    chapters = [
+        ChapterDraft(
+            chapter_number=1,
+            title="Signal",
+            outline_summary="Mara discovers the patch. Mode: investigation.",
+            content="Mara burns Nadia's access to expose the source node.",
+            summary="Mara burns Nadia's access.",
+            status=ChapterStatus.COMPLETED,
+        ),
+        ChapterDraft(
+            chapter_number=2,
+            title="Watchdog",
+            outline_summary="Mara proves the patch is manipulating compliance. Mode: aftermath.",
+            content="Mara again burns Nadia's access to expose the source node.",
+            summary="Mara repeats the same proof turn.",
+            status=ChapterStatus.COMPLETED,
+        ),
+    ]
+    for chapter in chapters:
+        chapter.continuity_update = {"story_turn": story_turn}
+
+    notes = manuscript_quality_notes(chapters, _story_bible())
+
+    assert any("equivalent irreversible story turns" in item for item in notes["story_turn_quality_notes"])
 
 
 def test_manuscript_lint_reports_meta_language_with_chapter_and_phrase() -> None:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -150,6 +150,15 @@ def _plan_json(index: int) -> str:
             "ideology_clash": f"Ideology clash {index}",
             "primary_interpersonal_conflict": f"Primary interpersonal conflict {index}",
             "independent_side_character_move": "Tarin resists",
+            "story_turn": {
+                "irreversible_change": f"Iris permanently changes leverage point {index}.",
+                "protagonist_choice": f"Iris chooses the costly path {index}.",
+                "choice_alternatives": [f"Iris could preserve the safer option {index}."],
+                "permanent_consequence": f"The mission state changes permanently {index}.",
+                "why_this_chapter_cannot_be_cut": f"Chapter {index} creates the required before-after state change.",
+                "state_before": f"State before {index}",
+                "state_after": f"State after {index}",
+            },
         }
     )
 
@@ -221,6 +230,15 @@ def _continuity_json(index: int) -> str:
             "civilian_pressure_points": [f"Civilian pressure {index}"],
             "emotional_open_loops": {"Iris": f"Emotional loop {index}"},
             "side_character_decisions": {"Tarin": [f"Tarin resists in chapter {index}"]},
+            "story_turn": {
+                "irreversible_change": f"Iris permanently changes leverage point {index}.",
+                "protagonist_choice": f"Iris chooses the costly path {index}.",
+                "choice_alternatives": [f"Iris could preserve the safer option {index}."],
+                "permanent_consequence": f"The mission state changes permanently {index}.",
+                "why_this_chapter_cannot_be_cut": f"Chapter {index} creates the required before-after state change.",
+                "state_before": f"State before {index}",
+                "state_after": f"State after {index}",
+            },
         }
     )
 
@@ -257,6 +275,7 @@ def _qa_report_json() -> str:
             "ideology_consistency_findings": ["Track whether Tarin's survival doctrine hardens intentionally."],
             "civilian_texture_findings": ["Show more concrete shelter life when the city locks down."],
             "technical_escalation_fatigue_findings": ["Watch for stacked alert language in late Act II."],
+            "story_turn_quality_notes": ["Chapter turns are mostly non-cuttable."],
         }
     )
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -132,6 +132,41 @@ def _outline_json(chapters: int) -> str:
     return json.dumps(payload)
 
 
+def _story_turn_payload(index: int) -> dict[str, object]:
+    turns: dict[int, dict[str, object]] = {
+        1: {
+            "irreversible_change": "Iris burns the archive master key to open the sealed maintenance stair.",
+            "protagonist_choice": "Iris sacrifices her last bargaining token instead of waiting for council permission.",
+            "choice_alternatives": ["Iris could hide the key and return to the council chamber."],
+            "permanent_consequence": "The archive can never lock the stair again, and Tarin loses his council escort.",
+            "why_this_chapter_cannot_be_cut": "Without the burned key, the stair remains sealed and the underground route never exists.",
+            "state_before": "The archive key still controls every lower stair.",
+            "state_after": "The maintenance stair is open, the key is ash, and Tarin is separated from his escort.",
+        },
+        2: {
+            "irreversible_change": "Iris signs the shelter families onto the living map, exposing their names to the buried system.",
+            "protagonist_choice": "Iris shares the route with the civilians instead of keeping it between herself and Tarin.",
+            "choice_alternatives": ["Iris could leave the families unmarked and move through the hatch alone."],
+            "permanent_consequence": "The buried system now tracks the shelter by name and demands Iris answer for them.",
+            "why_this_chapter_cannot_be_cut": "Without the named families on the map, Iris reaches the hatch without owing them protection.",
+            "state_before": "The shelter families are invisible to the map.",
+            "state_after": "The families glow on the map and the lower hatch recognizes Iris as their sponsor.",
+        },
+    }
+    return turns.get(
+        index,
+        {
+            "irreversible_change": f"Iris breaks beacon-{index} to reveal vault-{index}.",
+            "protagonist_choice": f"Iris chooses the exposed vault-{index} route over retreat.",
+            "choice_alternatives": [f"Iris could leave beacon-{index} untouched and withdraw."],
+            "permanent_consequence": f"Vault-{index} stays visible and cannot be hidden from Tarin.",
+            "why_this_chapter_cannot_be_cut": f"Without beacon-{index} breaking, vault-{index} never enters the route.",
+            "state_before": f"Beacon-{index} hides the vault path.",
+            "state_after": f"Vault-{index} is visible and the beacon is broken.",
+        },
+    )
+
+
 def _plan_json(index: int) -> str:
     return json.dumps(
         {
@@ -150,15 +185,7 @@ def _plan_json(index: int) -> str:
             "ideology_clash": f"Ideology clash {index}",
             "primary_interpersonal_conflict": f"Primary interpersonal conflict {index}",
             "independent_side_character_move": "Tarin resists",
-            "story_turn": {
-                "irreversible_change": f"Iris permanently changes leverage point {index}.",
-                "protagonist_choice": f"Iris chooses the costly path {index}.",
-                "choice_alternatives": [f"Iris could preserve the safer option {index}."],
-                "permanent_consequence": f"The mission state changes permanently {index}.",
-                "why_this_chapter_cannot_be_cut": f"Chapter {index} creates the required before-after state change.",
-                "state_before": f"State before {index}",
-                "state_after": f"State after {index}",
-            },
+            "story_turn": _story_turn_payload(index),
         }
     )
 
@@ -230,15 +257,7 @@ def _continuity_json(index: int) -> str:
             "civilian_pressure_points": [f"Civilian pressure {index}"],
             "emotional_open_loops": {"Iris": f"Emotional loop {index}"},
             "side_character_decisions": {"Tarin": [f"Tarin resists in chapter {index}"]},
-            "story_turn": {
-                "irreversible_change": f"Iris permanently changes leverage point {index}.",
-                "protagonist_choice": f"Iris chooses the costly path {index}.",
-                "choice_alternatives": [f"Iris could preserve the safer option {index}."],
-                "permanent_consequence": f"The mission state changes permanently {index}.",
-                "why_this_chapter_cannot_be_cut": f"Chapter {index} creates the required before-after state change.",
-                "state_before": f"State before {index}",
-                "state_after": f"State after {index}",
-            },
+            "story_turn": _story_turn_payload(index),
         }
     )
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -466,6 +466,25 @@ def test_outline_parser_rejects_chapter_mode_repeated_from_previous_two() -> Non
         raise AssertionError("Expected the outline parser to reject repeated recent chapter modes.")
 
 
+def test_chapter_plan_parser_requires_complete_story_turn() -> None:
+    try:
+        parse_chapter_plan(
+            """
+            {
+              "opening_state": "Iris hides in the maintenance shaft.",
+              "character_goal": "Reach Tarin.",
+              "scene_beats": ["Iris climbs", "Tarin blocks her"],
+              "conflict_turn": "Tarin refuses the shortcut.",
+              "ending_hook": "The door opens."
+            }
+            """
+        )
+    except ValueError as exc:
+        assert "complete story_turn" in str(exc)
+    else:
+        raise AssertionError("Expected chapter plans to require a complete story_turn.")
+
+
 def test_chapter_plan_critique_and_continuity_parsers_accept_richer_shapes() -> None:
     plan = parse_chapter_plan(
         """
@@ -486,7 +505,16 @@ def test_chapter_plan_critique_and_continuity_parsers_accept_richer_shapes() -> 
           "primary_interpersonal_conflict": "Tarin accuses Iris of treating people like systems.",
           "independent_side_character_move": "Tarin blocks the elevator route until Iris gives him the source shard.",
           "genre_specific_focus": "Keep the clue chain fair and visible.",
-          "genre_specific_beats": ["Iris misreads a planted clue", "Tarin notices the missing map seam"]
+          "genre_specific_beats": ["Iris misreads a planted clue", "Tarin notices the missing map seam"],
+          "story_turn": {
+            "irreversible_change": "Iris burns her archive badge and can no longer return through official doors.",
+            "protagonist_choice": "Iris chooses to burn the badge to draw drones away from Tarin.",
+            "choice_alternatives": ["Iris could keep the badge and leave Tarin exposed."],
+            "permanent_consequence": "The archive records Iris as a hostile intruder.",
+            "why_this_chapter_cannot_be_cut": "Without this chapter, Iris never loses official access or proves she will sacrifice status for Tarin.",
+            "state_before": "Iris can still pass as an archivist.",
+            "state_after": "Iris is locked out and Tarin knows she chose him over the archive."
+          }
         }
         """
     )
@@ -515,6 +543,9 @@ def test_chapter_plan_critique_and_continuity_parsers_accept_richer_shapes() -> 
           "sensory_specificity_score": 8,
           "dialogue_tension_score": 4,
           "technical_escalation_fatigue_score": 7,
+          "irreversibility_score": 5,
+          "choice_clarity_score": 6,
+          "cuttable_chapter_risk_score": 4,
           "blocking_issues": ["The ending does not land on the planned object/action beat."],
           "soft_warnings": ["Tarin could resist harder in scene two."],
           "genre_contract_findings": ["The chapter plants one clue but needs a cleaner deduction turn."],
@@ -543,6 +574,15 @@ def test_chapter_plan_critique_and_continuity_parsers_accept_richer_shapes() -> 
           "civilian_pressure_points": ["Families in the shelter lose archive access and heating."],
           "emotional_open_loops": {"Iris": "She fears she is choosing freedom with a damaged self."},
           "side_character_decisions": {"Tarin": ["Tarin blocks the elevator route until Iris gives him the source shard."]},
+          "story_turn": {
+            "irreversible_change": "Iris burns her badge and loses archive access.",
+            "protagonist_choice": "Iris chooses to protect Tarin instead of preserving her credentials.",
+            "choice_alternatives": ["Iris could keep her badge and leave Tarin exposed."],
+            "permanent_consequence": "Archive Security treats Iris as an intruder.",
+            "why_this_chapter_cannot_be_cut": "The manuscript needs Iris to lose institutional access before the undercity chase.",
+            "state_before": "Iris still has official access.",
+            "state_after": "Iris is cut off from the archive."
+          },
           "genre_state": {"clue_chain": "The first planted clue has been misread."}
         }
         """
@@ -557,12 +597,17 @@ def test_chapter_plan_critique_and_continuity_parsers_accept_richer_shapes() -> 
     assert critique.ideology_clarity_score == 8
     assert continuity.memory_damage["Iris"].startswith("She loses")
     assert plan.genre_specific_focus.startswith("Keep the clue chain")
+    assert plan.story_turn.irreversible_change.startswith("Iris burns")
     assert plan.independent_side_character_move.startswith("Tarin blocks")
     assert critique.genre_contract_score == 7
     assert critique.voice_distinctness_score == 5
     assert critique.dialogue_tension_score == 4
     assert critique.technical_escalation_fatigue_score == 7
+    assert critique.irreversibility_score == 5
+    assert critique.choice_clarity_score == 6
+    assert critique.cuttable_chapter_risk_score == 4
     assert continuity.genre_state["clue_chain"].startswith("The first planted clue")
+    assert continuity.story_turn.permanent_consequence.startswith("Archive Security")
     assert continuity.side_character_decisions["Tarin"][0].startswith("Tarin blocks")
 
 
@@ -715,6 +760,15 @@ def test_prompt_builders_include_prose_voice_profile() -> None:
         "conflict_turn": "Tarin blocks her.",
         "ending_hook": "The door opens.",
         "independent_side_character_move": "Tarin blocks the route until Iris admits the map may be manipulating her.",
+        "story_turn": {
+            "irreversible_change": "Iris gives Tarin the source route and loses unilateral control of the map.",
+            "protagonist_choice": "Iris chooses to admit the map may be manipulating her.",
+            "choice_alternatives": ["Iris could keep the route secret and force Tarin to follow."],
+            "permanent_consequence": "Tarin now has leverage over the undercity route.",
+            "why_this_chapter_cannot_be_cut": "Without it, Iris never gives up control or lets Tarin alter the mission.",
+            "state_before": "Iris controls the route alone.",
+            "state_after": "Tarin can block or redirect the mission.",
+        },
     }
     ledger = {
         "current_patch_status": "Unknown.",
@@ -776,6 +830,8 @@ def test_prompt_builders_include_prose_voice_profile() -> None:
     assert "Recent chapter modes to avoid repeating" in plan_prompt
     assert "previous 2 chapters" in plan_prompt
     assert "chapter_mode" in plan_prompt
+    assert "irreversible_change" in plan_prompt
+    assert "why_this_chapter_cannot_be_cut" in plan_prompt
     assert "Prose style profile" in draft_prompt
     assert "character_voice_map" in draft_prompt
     assert "final paragraph must include" in draft_prompt
@@ -783,11 +839,15 @@ def test_prompt_builders_include_prose_voice_profile() -> None:
     assert "at most one primary system-crisis mechanic" in draft_prompt
     assert "human-visible consequences" in draft_prompt
     assert "independent_side_character_move" in draft_prompt
+    assert "chapter_plan.story_turn" in draft_prompt
     assert "side characters who appear must pursue their own want" in draft_prompt
     assert "style_alignment_score" in critique_prompt
     assert "ending_hook_type" in critique_prompt
     assert "scene_turn_resolution_score" in critique_prompt
     assert "technical_escalation_fatigue_score" in critique_prompt
+    assert "irreversibility_score" in critique_prompt
+    assert "choice_clarity_score" in critique_prompt
+    assert "cuttable_chapter_risk_score" in critique_prompt
     assert "abstract_cliffhanger" in critique_prompt
     assert "next problem" in critique_prompt
     assert "meta/outlining language" in critique_prompt
@@ -795,6 +855,7 @@ def test_prompt_builders_include_prose_voice_profile() -> None:
     assert "side_character_independence_score should be 5 or lower" in critique_prompt
     assert "voice_and_texture" in critique_prompt
     assert "concrete external action" in revision_prompt
+    assert "unique protagonist choice and one permanent consequence" in revision_prompt
     assert "remove meta/outlining language" in revision_prompt
     assert "remove repeated alarm-console escalation" in revision_prompt
     assert "add or sharpen the planned independent_side_character_move" in revision_prompt


### PR DESCRIPTION
## What changed

- Added a structured `ChapterStoryTurn` with irreversible change, protagonist choice, alternatives, permanent consequence, cut-risk explanation, and before/after state.
- Required chapter planning to produce a complete story turn before drafting, and stored the actual completed turn in continuity updates.
- Added critique scores for irreversibility, choice clarity, and cuttable-chapter risk, with pipeline repair triggers when those scores are weak.
- Extended deterministic editorial QA to flag missing, abstract, reversible, or duplicated story turns across chapters.
- Added manuscript QA story-turn notes and surfaced the new scores in the run UI.
- Added focused tests for story-turn parsing, prompt coverage, linting, QA duplicate detection, and fake pipeline payloads.

Fixes #15.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Could not run `python -m pytest tests/test_editorial.py tests/test_prompts.py tests/test_pipeline.py` because this session has no `python` executable on PATH.