### PR TITLE
[codex] Add developmental rewrite pass

### DIFF
--- a/alembic/versions/0004_developmental_rewrite.py
+++ b/alembic/versions/0004_developmental_rewrite.py
@@ -1,0 +1,23 @@
+"""developmental rewrite pass flag"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0004_developmental_rewrite"
+down_revision = "0003_provider_routing"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "generation_runs",
+        sa.Column("developmental_rewrite_enabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("generation_runs", "developmental_rewrite_enabled")

--- a/src/novel_generator/models.py
+++ b/src/novel_generator/models.py
@@ -88,6 +88,7 @@ class GenerationRun(Base):
     max_words_per_chapter: Mapped[int] = mapped_column(Integer)
     pipeline_version: Mapped[int] = mapped_column(Integer, default=1)
     pause_after_outline: Mapped[bool] = mapped_column(Boolean, default=True)
+    developmental_rewrite_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     status: Mapped[RunStatus] = mapped_column(Enum(RunStatus), default=RunStatus.QUEUED)
     current_step: Mapped[str] = mapped_column(String(255), default="queued")
     current_chapter: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/src/novel_generator/repositories.py
+++ b/src/novel_generator/repositories.py
@@ -201,6 +201,7 @@ def create_run(session: Session, project: Project, payload: RunCreate) -> Genera
         max_words_per_chapter=max_words_per_chapter,
         pipeline_version=2,
         pause_after_outline=payload.pause_after_outline,
+        developmental_rewrite_enabled=payload.developmental_rewrite_enabled,
         task_routing=task_routing,
         status=RunStatus.QUEUED,
         current_step="queued",

--- a/src/novel_generator/routers/api.py
+++ b/src/novel_generator/routers/api.py
@@ -131,6 +131,7 @@ def _same_settings_payload(run, *, pause_after_outline: bool = True) -> RunCreat
         min_words_per_chapter=run.min_words_per_chapter,
         max_words_per_chapter=run.max_words_per_chapter,
         pause_after_outline=pause_after_outline,
+        developmental_rewrite_enabled=run.developmental_rewrite_enabled,
         task_routing=run.task_routing or {},
     )
 

--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -106,6 +106,13 @@ RUN_STAGES = [
         "result": "A QA report artifact should appear with strengths, warnings, and structural risks.",
     },
     {
+        "id": "developmental_rewrite",
+        "label": "Developmental rewrite",
+        "description": "Creating a full-manuscript structural rewrite plan when enabled.",
+        "why": "This optional stage turns QA risks into chapter-level keep, merge, cut, bridge, reorder, or rewrite actions.",
+        "result": "Rewrite report, revised-outline, and QA comparison artifacts should appear beside the manuscript exports.",
+    },
+    {
         "id": "export",
         "label": "Export",
         "description": "Rendering manuscript and QA artifacts.",
@@ -171,6 +178,7 @@ RUN_STAGE_PROGRESS_ORDER = [
     "chapter_revision",
     "chapter_summary",
     "manuscript_qa",
+    "developmental_rewrite",
     "export",
     "completed",
 ]
@@ -959,6 +967,7 @@ def _run_form_values(project: Project, values: dict[str, Any] | None = None) -> 
         "min_words_per_chapter": project.min_words_per_chapter,
         "max_words_per_chapter": project.max_words_per_chapter,
         "pause_after_outline": True,
+        "developmental_rewrite_enabled": False,
         **_task_routing_form_values(project.task_routing),
     }
     if values:
@@ -1596,6 +1605,7 @@ def _same_settings_payload(run: GenerationRun, *, source_run_id: str | None = No
         min_words_per_chapter=run.min_words_per_chapter,
         max_words_per_chapter=run.max_words_per_chapter,
         pause_after_outline=True,
+        developmental_rewrite_enabled=run.developmental_rewrite_enabled,
         task_routing=run.task_routing or {},
         source_run_id=source_run_id,
         resume_from_chapter=resume_from_chapter,
@@ -2238,6 +2248,7 @@ def create_run_ui(
     min_words_per_chapter: str = Form(""),
     max_words_per_chapter: str = Form(""),
     pause_after_outline: str | None = Form(None),
+    developmental_rewrite_enabled: str | None = Form(None),
     db: Session = Depends(get_db),
     settings: Settings = Depends(get_app_settings),
 ):
@@ -2253,6 +2264,7 @@ def create_run_ui(
         "min_words_per_chapter": min_words_per_chapter,
         "max_words_per_chapter": max_words_per_chapter,
         "pause_after_outline": _coerce_checkbox(pause_after_outline),
+        "developmental_rewrite_enabled": _coerce_checkbox(developmental_rewrite_enabled),
     }
     provider_configs_by_name, provider_statuses_by_name, manager = _provider_catalog(settings, db)
 

--- a/src/novel_generator/schemas.py
+++ b/src/novel_generator/schemas.py
@@ -568,6 +568,82 @@ class ManuscriptQaReport(BaseModel):
         return _clean_list(value)
 
 
+class DevelopmentalChapterAction(BaseModel):
+    chapter_numbers: list[int] = Field(default_factory=list)
+    action: str = "rewrite"
+    reason: str = ""
+    required_story_change: str = ""
+    permanent_consequence: str = ""
+
+    @field_validator("chapter_numbers", mode="before")
+    @classmethod
+    def validate_chapter_numbers(cls, value: Any) -> list[int]:
+        if value is None:
+            return []
+        if isinstance(value, int):
+            return [value]
+        if isinstance(value, str):
+            value = [item.strip() for item in value.replace(",", "\n").splitlines()]
+        if isinstance(value, list):
+            numbers: list[int] = []
+            for item in value:
+                try:
+                    number = int(str(item).strip())
+                except ValueError:
+                    continue
+                if number > 0:
+                    numbers.append(number)
+            return list(dict.fromkeys(numbers))
+        return []
+
+    @field_validator("action", mode="before")
+    @classmethod
+    def validate_action(cls, value: Any) -> str:
+        action = str(value or "rewrite").strip().lower().replace("-", "_").replace(" ", "_")
+        return action or "rewrite"
+
+    @field_validator("reason", "required_story_change", "permanent_consequence", mode="before")
+    @classmethod
+    def validate_action_strings(cls, value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+
+class DevelopmentalRewritePlan(BaseModel):
+    overall_diagnosis: str = "Developmental rewrite assessment completed."
+    act_structure_notes: list[str] = Field(default_factory=list)
+    chapter_actions: list[DevelopmentalChapterAction] = Field(default_factory=list)
+    merge_candidates: list[str] = Field(default_factory=list)
+    cut_candidates: list[str] = Field(default_factory=list)
+    continuity_repairs: list[str] = Field(default_factory=list)
+    theme_arc_repairs: list[str] = Field(default_factory=list)
+    prose_pattern_repairs: list[str] = Field(default_factory=list)
+    pre_rewrite_risks: list[str] = Field(default_factory=list)
+    post_rewrite_risk_targets: list[str] = Field(default_factory=list)
+
+    @field_validator("overall_diagnosis", mode="before")
+    @classmethod
+    def validate_overall_diagnosis(cls, value: Any) -> str:
+        rendered = str(value or "").strip()
+        return rendered or "Developmental rewrite assessment completed."
+
+    @field_validator(
+        "act_structure_notes",
+        "merge_candidates",
+        "cut_candidates",
+        "continuity_repairs",
+        "theme_arc_repairs",
+        "prose_pattern_repairs",
+        "pre_rewrite_risks",
+        "post_rewrite_risk_targets",
+        mode="before",
+    )
+    @classmethod
+    def validate_plan_lists(cls, value: Any) -> list[str]:
+        return _clean_list(value)
+
+
 class TaskRouteOverride(BaseModel):
     provider_name: str = Field(min_length=1)
     model_name: str = Field(min_length=1)
@@ -590,6 +666,7 @@ class TaskRouting(BaseModel):
     chapter_summary: TaskRouteOverride | None = None
     continuity_update: TaskRouteOverride | None = None
     manuscript_qa: TaskRouteOverride | None = None
+    developmental_rewrite: TaskRouteOverride | None = None
 
 
 class ProviderCapabilities(BaseModel):
@@ -724,6 +801,7 @@ class RunCreate(BaseModel):
     min_words_per_chapter: int | None = Field(default=None, ge=1)
     max_words_per_chapter: int | None = Field(default=None, ge=1)
     pause_after_outline: bool = True
+    developmental_rewrite_enabled: bool = False
     task_routing: TaskRouting | None = None
     source_run_id: str | None = None
     resume_from_chapter: int | None = Field(default=None, ge=1)
@@ -743,6 +821,7 @@ class GenerationRunRead(BaseModel):
     max_words_per_chapter: int
     pipeline_version: int
     pause_after_outline: bool
+    developmental_rewrite_enabled: bool
     status: RunStatus
     current_step: str
     current_chapter: int | None

--- a/src/novel_generator/services/editorial.py
+++ b/src/novel_generator/services/editorial.py
@@ -11,6 +11,7 @@ from ..schemas import (
     CanonicalEntity,
     ChapterPlan,
     ContinuityLedger,
+    DevelopmentalRewritePlan,
     ManuscriptQaReport,
     StoryBible,
     StructuredOutlineEntry,
@@ -1771,4 +1772,145 @@ def render_qa_report_markdown(report: ManuscriptQaReport) -> str:
         *([f"- {item}" for item in report.lint_findings] or ["- No deterministic lint findings recorded."]),
         "",
     ]
+    return "\n".join(sections).strip() + "\n"
+
+
+def render_developmental_rewrite_report_markdown(
+    plan: DevelopmentalRewritePlan,
+    qa_report: ManuscriptQaReport,
+) -> str:
+    action_lines = []
+    for item in plan.chapter_actions:
+        chapters = ", ".join(f"Chapter {number}" for number in item.chapter_numbers) or "Unassigned chapter"
+        action_lines.extend(
+            [
+                f"### {chapters}: {item.action.replace('_', ' ').title()}",
+                "",
+                f"- Reason: {item.reason or 'No reason recorded.'}",
+                f"- Required story change: {item.required_story_change or 'No required story change recorded.'}",
+                f"- Permanent consequence: {item.permanent_consequence or 'No permanent consequence recorded.'}",
+                "",
+            ]
+        )
+    sections = [
+        "# Developmental Rewrite Report",
+        "",
+        f"**Overall diagnosis:** {plan.overall_diagnosis}",
+        "",
+        "## Act Structure Notes",
+        "",
+        *([f"- {item}" for item in plan.act_structure_notes] or ["- No act-structure notes recorded."]),
+        "",
+        "## Chapter Actions",
+        "",
+        *(action_lines or ["- No chapter actions recorded.", ""]),
+        "## Merge Candidates",
+        "",
+        *([f"- {item}" for item in plan.merge_candidates] or ["- No merge candidates recorded."]),
+        "",
+        "## Cut Candidates",
+        "",
+        *([f"- {item}" for item in plan.cut_candidates] or ["- No cut candidates recorded."]),
+        "",
+        "## Continuity Repairs",
+        "",
+        *([f"- {item}" for item in plan.continuity_repairs] or ["- No continuity repairs recorded."]),
+        "",
+        "## Theme Arc Repairs",
+        "",
+        *([f"- {item}" for item in plan.theme_arc_repairs] or ["- No theme-arc repairs recorded."]),
+        "",
+        "## Prose Pattern Repairs",
+        "",
+        *([f"- {item}" for item in plan.prose_pattern_repairs] or ["- No prose-pattern repairs recorded."]),
+        "",
+        "## QA Comparison",
+        "",
+        "### Pre-Rewrite Risks",
+        "",
+        *(
+            [f"- {item}" for item in plan.pre_rewrite_risks]
+            or [f"- {item}" for item in [*qa_report.warnings, *qa_report.repetition_risks, *qa_report.continuity_risks]]
+            or ["- No pre-rewrite risks recorded."]
+        ),
+        "",
+        "### Post-Rewrite Risk Targets",
+        "",
+        *([f"- {item}" for item in plan.post_rewrite_risk_targets] or ["- No post-rewrite risk targets recorded."]),
+        "",
+    ]
+    return "\n".join(sections).strip() + "\n"
+
+
+def render_developmental_qa_comparison_markdown(
+    plan: DevelopmentalRewritePlan,
+    qa_report: ManuscriptQaReport,
+) -> str:
+    pre_rewrite_risks = (
+        plan.pre_rewrite_risks
+        or [
+            *qa_report.warnings,
+            *qa_report.continuity_risks,
+            *qa_report.repetition_risks,
+            *qa_report.chapter_ending_quality_notes,
+            *qa_report.technical_escalation_fatigue_findings,
+            *qa_report.story_turn_quality_notes,
+        ]
+    )
+    sections = [
+        "# Developmental QA Comparison",
+        "",
+        f"**Pre-rewrite verdict:** {qa_report.overall_verdict}",
+        "",
+        "## Pre-Rewrite Risks",
+        "",
+        *([f"- {item}" for item in pre_rewrite_risks] or ["- No pre-rewrite risks recorded."]),
+        "",
+        "## Post-Rewrite Risk Targets",
+        "",
+        *([f"- {item}" for item in plan.post_rewrite_risk_targets] or ["- No post-rewrite risk targets recorded."]),
+        "",
+        "## Verification Focus",
+        "",
+        "- Run manuscript QA again after applying the revised outline.",
+        "- Confirm cut or merged chapters still preserve their permanent consequences.",
+        "- Confirm repetition, continuity, and cuttable-chapter risks trend down from the pre-rewrite report.",
+        "",
+    ]
+    return "\n".join(sections).strip() + "\n"
+
+
+def render_revised_outline_markdown(
+    project_title: str,
+    plan: DevelopmentalRewritePlan,
+    chapters: list[ChapterDraft],
+) -> str:
+    chapter_lookup = {chapter.chapter_number: chapter for chapter in chapters}
+    sections = [
+        "# Revised Outline",
+        "",
+        f"Project: {project_title}",
+        "",
+        "This outline is a developmental rewrite map, not rewritten prose.",
+        "",
+    ]
+    for item in plan.chapter_actions:
+        chapters = [chapter_lookup.get(number) for number in item.chapter_numbers]
+        titles = [
+            f"Chapter {chapter.chapter_number}: {chapter.title}"
+            for chapter in chapters
+            if chapter is not None
+        ]
+        heading = ", ".join(titles) or ", ".join(f"Chapter {number}" for number in item.chapter_numbers) or "Unassigned chapter"
+        sections.extend(
+            [
+                f"## {heading}",
+                "",
+                f"- Action: {item.action.replace('_', ' ').title()}",
+                f"- Reason: {item.reason or 'No reason recorded.'}",
+                f"- Required story change: {item.required_story_change or 'No required story change recorded.'}",
+                f"- Permanent consequence: {item.permanent_consequence or 'No permanent consequence recorded.'}",
+                "",
+            ]
+        )
     return "\n".join(sections).strip() + "\n"

--- a/src/novel_generator/services/exports.py
+++ b/src/novel_generator/services/exports.py
@@ -148,6 +148,9 @@ def export_run_artifacts(
     run: GenerationRun,
     chapters: list[ChapterDraft],
     qa_report_markdown: str | None = None,
+    developmental_rewrite_markdown: str | None = None,
+    revised_outline_markdown: str | None = None,
+    developmental_qa_markdown: str | None = None,
 ) -> list[Artifact]:
     run_dir = artifacts_dir / run.id
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -183,6 +186,42 @@ def export_run_artifacts(
                 kind="qa-report",
                 filename=qa_name,
                 relative_path=str(qa_path.relative_to(artifacts_dir)),
+                content_type="text/markdown",
+            )
+        )
+    if developmental_rewrite_markdown is not None:
+        rewrite_name = "developmental-rewrite-report.md"
+        rewrite_path = run_dir / rewrite_name
+        rewrite_path.write_text(developmental_rewrite_markdown, encoding="utf-8")
+        artifacts.append(
+            Artifact(
+                kind="developmental-rewrite-report",
+                filename=rewrite_name,
+                relative_path=str(rewrite_path.relative_to(artifacts_dir)),
+                content_type="text/markdown",
+            )
+        )
+    if revised_outline_markdown is not None:
+        outline_name = "revised-outline.md"
+        outline_path = run_dir / outline_name
+        outline_path.write_text(revised_outline_markdown, encoding="utf-8")
+        artifacts.append(
+            Artifact(
+                kind="revised-outline",
+                filename=outline_name,
+                relative_path=str(outline_path.relative_to(artifacts_dir)),
+                content_type="text/markdown",
+            )
+        )
+    if developmental_qa_markdown is not None:
+        qa_comparison_name = "developmental-qa-comparison.md"
+        qa_comparison_path = run_dir / qa_comparison_name
+        qa_comparison_path.write_text(developmental_qa_markdown, encoding="utf-8")
+        artifacts.append(
+            Artifact(
+                kind="developmental-qa-report",
+                filename=qa_comparison_name,
+                relative_path=str(qa_comparison_path.relative_to(artifacts_dir)),
                 content_type="text/markdown",
             )
         )

--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -15,6 +15,7 @@ from ..schemas import (
     ChapterPlan,
     CanonicalEntity,
     ContinuityLedger,
+    DevelopmentalRewritePlan,
     ManuscriptQaReport,
     StoryBible,
     StructuredOutlineEntry,
@@ -28,7 +29,10 @@ from .editorial import (
     lint_manuscript,
     manuscript_quality_notes,
     merge_canonical_entities,
+    render_developmental_qa_comparison_markdown,
+    render_developmental_rewrite_report_markdown,
     render_qa_report_markdown,
+    render_revised_outline_markdown,
 )
 from .exports import export_run_artifacts
 from .genre_profiles import genre_profile
@@ -40,6 +44,7 @@ from .prompts import (
     build_chapter_plan_messages,
     build_chapter_revision_messages,
     build_continuity_update_messages,
+    build_developmental_rewrite_messages,
     build_json_repair_messages,
     build_manuscript_qa_messages,
     build_outline_messages,
@@ -48,6 +53,7 @@ from .prompts import (
     parse_chapter_critique,
     parse_chapter_plan,
     parse_continuity_update,
+    parse_developmental_rewrite_plan,
     parse_manuscript_qa_report,
     parse_outline,
     parse_story_bible,
@@ -854,6 +860,104 @@ def _run_manuscript_qa(
     return qa_report, qa_markdown
 
 
+def _fallback_developmental_rewrite_plan(
+    chapters: list,
+    qa_report: ManuscriptQaReport,
+) -> DevelopmentalRewritePlan:
+    pre_rewrite_risks = _dedupe(
+        [
+            *qa_report.warnings,
+            *qa_report.continuity_risks,
+            *qa_report.repetition_risks,
+            *qa_report.chapter_ending_quality_notes,
+            *qa_report.technical_escalation_fatigue_findings,
+            *qa_report.scene_mode_distribution_notes,
+            *qa_report.story_turn_quality_notes,
+        ]
+    )
+    chapter_actions = []
+    for chapter in chapters:
+        qa_notes = chapter.qa_notes or {}
+        cuttable_risk = int(qa_notes.get("cuttable_chapter_risk_score") or 0)
+        repetition_risk = int(qa_notes.get("repetition_risk_score") or 0)
+        revision_required = bool(qa_notes.get("revision_required"))
+        action = "rewrite" if revision_required or cuttable_risk >= 6 or repetition_risk >= 7 else "keep"
+        reason = "Chapter-level QA indicates structural risk." if action == "rewrite" else "Chapter has a stored story turn and no high deterministic risk."
+        story_turn = (chapter.continuity_update or {}).get("story_turn", {}) if isinstance(chapter.continuity_update, dict) else {}
+        chapter_actions.append(
+            {
+                "chapter_numbers": [chapter.chapter_number],
+                "action": action,
+                "reason": reason,
+                "required_story_change": story_turn.get("why_this_chapter_cannot_be_cut") or chapter.outline_summary,
+                "permanent_consequence": story_turn.get("permanent_consequence") or "Preserve a concrete before/after state change.",
+            }
+        )
+    return DevelopmentalRewritePlan(
+        overall_diagnosis=(
+            "Deterministic developmental rewrite plan generated from manuscript QA because the model rewrite plan was unavailable."
+        ),
+        act_structure_notes=["Review chapter actions against the original act plan before rewriting prose."],
+        chapter_actions=chapter_actions,
+        pre_rewrite_risks=pre_rewrite_risks,
+        post_rewrite_risk_targets=[
+            "Every retained or rewritten chapter should carry a distinct irreversible story turn.",
+            "Merged or cut chapters should preserve any necessary permanent consequence elsewhere.",
+            "A follow-up QA pass should show lower repetition, continuity, and cuttable-chapter risk.",
+        ],
+    )
+
+
+def _run_developmental_rewrite(
+    session: Session,
+    run: GenerationRun,
+    chapters: list,
+    qa_report: ManuscriptQaReport,
+    client: ProviderManager | OllamaClient,
+) -> tuple[str, str, str]:
+    story_bible = _story_bible_from_run(run)
+    continuity_ledger = _continuity_ledger_from_run(run)
+    provider_name, model_name = _resolve_stage_route(client, run, "developmental_rewrite")
+    run.current_step = "developmental_rewrite"
+    record_event(
+        session,
+        run,
+        "developmental_rewrite_started",
+        {"message": "Planning a developmental rewrite.", "provider_name": provider_name, "model_name": model_name},
+    )
+    session.commit()
+    try:
+        plan = _generate_structured_output(
+            client,
+            provider_name,
+            model_name,
+            lambda: build_developmental_rewrite_messages(run.project, story_bible, continuity_ledger, qa_report, chapters),
+            parse_developmental_rewrite_plan,
+            "developmental rewrite plan",
+        )
+    except Exception as exc:
+        record_event(
+            session,
+            run,
+            "developmental_rewrite_fallback",
+            {"message": "Developmental rewrite model output was unusable; generated a deterministic plan.", "error": str(exc)},
+        )
+        session.commit()
+        plan = _fallback_developmental_rewrite_plan(chapters, qa_report)
+
+    rewrite_markdown = render_developmental_rewrite_report_markdown(plan, qa_report)
+    revised_outline_markdown = render_revised_outline_markdown(run.project.title, plan, chapters)
+    developmental_qa_markdown = render_developmental_qa_comparison_markdown(plan, qa_report)
+    record_event(
+        session,
+        run,
+        "developmental_rewrite_completed",
+        {"message": "Developmental rewrite plan created.", "chapter_action_count": len(plan.chapter_actions)},
+    )
+    session.commit()
+    return rewrite_markdown, revised_outline_markdown, developmental_qa_markdown
+
+
 def process_run(session: Session, run: GenerationRun, settings: Settings, client: ProviderManager | OllamaClient) -> None:
     _ensure_not_canceled(session, run)
 
@@ -903,13 +1007,33 @@ def process_run(session: Session, run: GenerationRun, settings: Settings, client
             + ", ".join(str(chapter_number) for chapter_number in incomplete_chapters)
         )
 
-    _, qa_markdown = _run_manuscript_qa(session, run, completed_chapters, client)
+    qa_report, qa_markdown = _run_manuscript_qa(session, run, completed_chapters, client)
+    rewrite_markdown = None
+    revised_outline_markdown = None
+    developmental_qa_markdown = None
+    if run.developmental_rewrite_enabled:
+        rewrite_markdown, revised_outline_markdown, developmental_qa_markdown = _run_developmental_rewrite(
+            session,
+            run,
+            completed_chapters,
+            qa_report,
+            client,
+        )
 
     run.current_step = "export"
     record_event(session, run, "artifact_export_started", {"message": "Rendering manuscript artifacts."})
     session.commit()
 
-    artifacts = export_run_artifacts(settings.artifacts_dir, run.project, run, completed_chapters, qa_markdown)
+    artifacts = export_run_artifacts(
+        settings.artifacts_dir,
+        run.project,
+        run,
+        completed_chapters,
+        qa_markdown,
+        rewrite_markdown,
+        revised_outline_markdown,
+        developmental_qa_markdown,
+    )
     replace_artifacts(session, run, artifacts)
     run.current_step = "completed"
     run.current_chapter = None

--- a/src/novel_generator/services/prompts.py
+++ b/src/novel_generator/services/prompts.py
@@ -14,6 +14,7 @@ from ..schemas import (
     ChapterCritique,
     ChapterPlan,
     ContinuityLedger,
+    DevelopmentalRewritePlan,
     ManuscriptQaReport,
     StoryBible,
     StructuredOutlineEntry,
@@ -873,6 +874,75 @@ def build_manuscript_qa_messages(
     ]
 
 
+def build_developmental_rewrite_messages(
+    project: Project,
+    story_bible: StoryBible | dict[str, Any],
+    continuity_ledger: ContinuityLedger | dict[str, Any] | None,
+    qa_report: ManuscriptQaReport,
+    chapters: list[ChapterDraft],
+) -> list[dict[str, str]]:
+    bible = story_bible if isinstance(story_bible, dict) else story_bible.model_dump()
+    ledger = continuity_ledger if isinstance(continuity_ledger, dict) else (continuity_ledger.model_dump() if continuity_ledger else {})
+    profile = _story_bible_genre_profile(bible)
+    chapter_payload = [
+        {
+            "chapter_number": chapter.chapter_number,
+            "title": chapter.title,
+            "outline_summary": chapter.outline_summary,
+            "summary": chapter.summary or "",
+            "word_count": chapter.word_count,
+            "story_turn": _chapter_continuity_payload(chapter).get("story_turn", {}),
+            "qa_notes": chapter.qa_notes or {},
+            "content": sanitize_chapter_content(chapter.content or ""),
+        }
+        for chapter in chapters
+    ]
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a developmental editor planning structural rewrites for AI-generated fiction. "
+                "Return valid JSON only. Do not rewrite prose; diagnose structure and produce actionable chapter-map changes."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Create a developmental rewrite plan for '{project.title}'.\n\n"
+                f"Story bible:\n{json.dumps(bible, indent=2)}\n\n"
+                f"Continuity ledger:\n{json.dumps(ledger, indent=2)}\n\n"
+                f"Selected genre profile:\n{_genre_profile_block(profile)}\n\n"
+                f"Pre-rewrite manuscript QA report:\n{json.dumps(qa_report.model_dump(), indent=2)}\n\n"
+                f"Full manuscript chapters:\n{json.dumps(chapter_payload, indent=2)}\n\n"
+                "Return a JSON object with exactly these keys:\n"
+                "{\n"
+                '  "overall_diagnosis": "string",\n'
+                '  "act_structure_notes": ["string"],\n'
+                '  "chapter_actions": [\n'
+                "    {\n"
+                '      "chapter_numbers": [1],\n'
+                '      "action": "keep|merge|cut|rewrite|bridge|reorder",\n'
+                '      "reason": "string",\n'
+                '      "required_story_change": "string",\n'
+                '      "permanent_consequence": "string"\n'
+                "    }\n"
+                "  ],\n"
+                '  "merge_candidates": ["string"],\n'
+                '  "cut_candidates": ["string"],\n'
+                '  "continuity_repairs": ["string"],\n'
+                '  "theme_arc_repairs": ["string"],\n'
+                '  "prose_pattern_repairs": ["string"],\n'
+                '  "pre_rewrite_risks": ["string"],\n'
+                '  "post_rewrite_risk_targets": ["string"]\n'
+                "}\n\n"
+                "Every chapter must appear in chapter_actions. Identify chapters that do not permanently change the story. "
+                "Use merge or cut only when the story can preserve the permanent consequence elsewhere. "
+                "The post_rewrite_risk_targets field should compare the current QA risks with what the revised outline must prove has improved."
+            ),
+        },
+    ]
+
+
 def build_json_repair_messages(raw_text: str, label: str, issue: str | None = None) -> list[dict[str, str]]:
     issue_text = f"\nParser or schema error:\n{issue}\n\n" if issue else "\n"
     return [
@@ -1093,6 +1163,16 @@ def parse_manuscript_qa_report(text: str) -> ManuscriptQaReport:
     if isinstance(payload, dict) and "qa_report" in payload:
         payload = payload["qa_report"]
     return ManuscriptQaReport.model_validate(payload)
+
+
+def parse_developmental_rewrite_plan(text: str) -> DevelopmentalRewritePlan:
+    payload = extract_json_payload(text)
+    if isinstance(payload, dict):
+        for key in ("developmental_rewrite_plan", "rewrite_plan", "plan"):
+            if key in payload:
+                payload = payload[key]
+                break
+    return DevelopmentalRewritePlan.model_validate(payload)
 
 
 def sanitize_chapter_content(content: str) -> str:

--- a/src/novel_generator/services/providers.py
+++ b/src/novel_generator/services/providers.py
@@ -21,6 +21,7 @@ TASK_ROUTE_STAGES: list[dict[str, str]] = [
     {"id": "chapter_summary", "label": "Chapter summary"},
     {"id": "continuity_update", "label": "Continuity update"},
     {"id": "manuscript_qa", "label": "Manuscript QA"},
+    {"id": "developmental_rewrite", "label": "Developmental rewrite"},
 ]
 TASK_ROUTE_STAGE_IDS = tuple(item["id"] for item in TASK_ROUTE_STAGES)
 TASK_ROUTE_LABELS = {item["id"]: item["label"] for item in TASK_ROUTE_STAGES}

--- a/src/novel_generator/templates/project_detail.html
+++ b/src/novel_generator/templates/project_detail.html
@@ -507,16 +507,24 @@
         <span class="field-note">Recommended for long runs. Turn it off when you trust the project brief and want the worker to draft straight through.</span>
       </label>
 
+      <label class="toggle-card run-mode-card">
+        <span class="toggle-input">
+          <input type="checkbox" name="developmental_rewrite_enabled" value="1" {% if run_values.developmental_rewrite_enabled %}checked{% endif %}>
+          <strong>Run developmental rewrite planning</strong>
+        </span>
+        <span class="field-note">After manuscript QA, produce a structural rewrite report, revised outline, and QA comparison for merge, cut, bridge, reorder, or rewrite decisions.</span>
+      </label>
+
       <div
         class="inline-note inline-note-success run-mode-note"
         data-run-mode-note
-        data-pause-message="Build the story bible and outline, wait for approval, then draft chapters, run editorial QA, and export artifacts."
-        data-straight-message="Move straight from story bible and outline generation into chapter drafting, editorial QA, and export."
+        data-pause-message="Build the story bible and outline, wait for approval, then draft chapters, run editorial QA, optional developmental rewrite planning, and export artifacts."
+        data-straight-message="Move straight from story bible and outline generation into chapter drafting, editorial QA, optional developmental rewrite planning, and export."
       >
         {% if run_values.pause_after_outline %}
-          Build the story bible and outline, wait for approval, then draft chapters, run editorial QA, and export artifacts.
+          Build the story bible and outline, wait for approval, then draft chapters, run editorial QA, optional developmental rewrite planning, and export artifacts.
         {% else %}
-          Move straight from story bible and outline generation into chapter drafting, editorial QA, and export.
+          Move straight from story bible and outline generation into chapter drafting, editorial QA, optional developmental rewrite planning, and export.
         {% endif %}
       </div>
 
@@ -568,6 +576,13 @@
           <div>
             <strong>Run editorial QA before export</strong>
             <p class="field-note">The QA report calls out repetition, continuity drift, and ending issues instead of silently shipping them.</p>
+          </div>
+        </li>
+        <li class="run-flow-item">
+          <span class="run-flow-number">5</span>
+          <div>
+            <strong>Plan a developmental rewrite</strong>
+            <p class="field-note">Optional full-manuscript planning converts QA risks into structural actions, a revised outline, and a before/after QA comparison.</p>
           </div>
         </li>
       </ol>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -35,7 +35,12 @@ def create_project_payload() -> dict:
     }
 
 
-def create_project_and_run(client, *, pause_after_outline: bool = True) -> tuple[str, str]:
+def create_project_and_run(
+    client,
+    *,
+    pause_after_outline: bool = True,
+    developmental_rewrite_enabled: bool = False,
+) -> tuple[str, str]:
     project_response = client.post("/api/projects", json=create_project_payload())
     assert project_response.status_code == 201
     project_id = project_response.json()["id"]
@@ -46,6 +51,7 @@ def create_project_and_run(client, *, pause_after_outline: bool = True) -> tuple
             "project_id": project_id,
             "model_name": "test-model",
             "pause_after_outline": pause_after_outline,
+            "developmental_rewrite_enabled": developmental_rewrite_enabled,
         },
     )
     assert run_response.status_code == 201
@@ -61,6 +67,7 @@ def test_project_and_run_api_flow(client, monkeypatch) -> None:
     assert detail_response.status_code == 200
     assert detail_response.json()["project_id"] == project_id
     assert detail_response.json()["pause_after_outline"] is True
+    assert detail_response.json()["developmental_rewrite_enabled"] is False
 
     cancel_response = client.post(f"/api/runs/{run_id}/cancel")
     assert cancel_response.status_code == 200
@@ -139,7 +146,11 @@ def test_invalid_model_is_rejected_when_queueing_run(client, monkeypatch) -> Non
 def test_rerun_api_requeues_same_settings_as_v2_run(client, monkeypatch) -> None:
     monkeypatch.setattr(OllamaClient, "list_models", lambda self: ["test-model"])
 
-    project_id, run_id = create_project_and_run(client, pause_after_outline=False)
+    project_id, run_id = create_project_and_run(
+        client,
+        pause_after_outline=False,
+        developmental_rewrite_enabled=True,
+    )
     session_factory = get_session_factory()
     with session_factory() as session:
         run = get_run(session, run_id)
@@ -156,6 +167,7 @@ def test_rerun_api_requeues_same_settings_as_v2_run(client, monkeypatch) -> None
     assert rerun_response.json()["status"] == "queued"
     assert rerun_response.json()["pipeline_version"] == 2
     assert rerun_response.json()["pause_after_outline"] is True
+    assert rerun_response.json()["developmental_rewrite_enabled"] is True
     assert rerun_response.json()["id"] != run_id
 
 

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -53,6 +53,52 @@ def test_export_run_artifacts_writes_manuscript_and_qa_report_without_duplicate_
     assert "# QA Report" in qa_report
 
 
+def test_export_run_artifacts_writes_developmental_rewrite_outputs(tmp_path) -> None:
+    project = Project(
+        title="The Glass Orchard",
+        premise="A disgraced archivist finds a living map under a failing city.",
+        desired_word_count=2000,
+        requested_chapters=1,
+        min_words_per_chapter=900,
+        max_words_per_chapter=1200,
+        preferred_provider_name="ollama",
+        preferred_model="test-model",
+        task_routing={},
+    )
+    run = GenerationRun(
+        id="run-1",
+        project_id="project-1",
+        provider_name="ollama",
+        model_name="test-model",
+        target_word_count=2000,
+        requested_chapters=1,
+        min_words_per_chapter=900,
+        max_words_per_chapter=1200,
+        task_routing={},
+        current_step="completed",
+    )
+    chapters = [ChapterDraft(chapter_number=1, title="Arrival", outline_summary="Wake the map.", content="A beginning.")]
+
+    artifacts = export_run_artifacts(
+        tmp_path,
+        project,
+        run,
+        chapters,
+        "# QA Report\n",
+        "# Developmental Rewrite Report\n",
+        "# Revised Outline\n",
+        "# Developmental QA Comparison\n",
+    )
+
+    artifact_kinds = {artifact.kind for artifact in artifacts}
+    assert "developmental-rewrite-report" in artifact_kinds
+    assert "revised-outline" in artifact_kinds
+    assert "developmental-qa-report" in artifact_kinds
+    assert (tmp_path / "run-1" / "developmental-rewrite-report.md").exists()
+    assert (tmp_path / "run-1" / "revised-outline.md").exists()
+    assert (tmp_path / "run-1" / "developmental-qa-comparison.md").exists()
+
+
 def test_publication_docx_profile_adds_front_matter_page_size_and_page_breaks(tmp_path) -> None:
     project = Project(
         title="The Glass Orchard",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -299,6 +299,31 @@ def _qa_report_json() -> str:
     )
 
 
+def _developmental_rewrite_json() -> str:
+    return json.dumps(
+        {
+            "overall_diagnosis": "The draft needs one structural compression pass after QA.",
+            "act_structure_notes": ["Act I works but should externalize the cost sooner."],
+            "chapter_actions": [
+                {
+                    "chapter_numbers": [1],
+                    "action": "rewrite",
+                    "reason": "Make the archive breach cost a named relationship.",
+                    "required_story_change": "Force Iris to burn the archive key in view of Tarin.",
+                    "permanent_consequence": "The lower stair stays open and Tarin loses his escort.",
+                }
+            ],
+            "merge_candidates": [],
+            "cut_candidates": [],
+            "continuity_repairs": ["Track the burned archive key in the ledger."],
+            "theme_arc_repairs": ["Tie consent to a visible loss of access."],
+            "prose_pattern_repairs": ["Remove future-hangs summary language."],
+            "pre_rewrite_risks": ["One technical escape is too smooth."],
+            "post_rewrite_risk_targets": ["Revised chapter should show a distinct permanent consequence."],
+        }
+    )
+
+
 class FakeOllamaClient:
     def __init__(self, responses: list[str]):
         self._responses = iter(responses)
@@ -434,6 +459,56 @@ def test_approved_run_completes_and_generates_qa_report(configured_environment) 
         assert len(refreshed.artifacts) == 3
         assert any(artifact.kind == "qa-report" for artifact in refreshed.artifacts)
         assert refreshed.summary_context is not None
+
+
+def test_developmental_rewrite_pass_exports_report_and_revised_outline(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=1)
+        run = create_run(
+            session,
+            project,
+            RunCreate(
+                project_id=project.id,
+                model_name="test-model",
+                pause_after_outline=False,
+                developmental_rewrite_enabled=True,
+            ),
+        )
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient(
+                [
+                    _story_bible_json(),
+                    _outline_json(1),
+                    _plan_json(1),
+                    (
+                        "Iris slips out of the archive while Tarin resists following her. "
+                        "Trigger 1 arrives when the visible actor 1 seals the corridor, leaving only route 1 below them."
+                    ),
+                    _critique_json(revision_required=False),
+                    "Iris discovers the living map and commits to following it underground.",
+                    _continuity_json(1),
+                    _qa_report_json(),
+                    _developmental_rewrite_json(),
+                ]
+            ),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.COMPLETED
+        artifact_kinds = {artifact.kind for artifact in refreshed.artifacts}
+        assert "developmental-rewrite-report" in artifact_kinds
+        assert "revised-outline" in artifact_kinds
+        assert "developmental-qa-report" in artifact_kinds
+        assert any(event.event_type == "developmental_rewrite_completed" for event in refreshed.events)
 
 
 def test_manuscript_qa_fallback_completes_when_model_output_stays_invalid(configured_environment) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,10 +6,12 @@ from novel_generator.services.prompts import (
     build_chapter_draft_messages,
     build_chapter_plan_messages,
     build_chapter_revision_messages,
+    build_developmental_rewrite_messages,
     build_story_bible_messages,
     parse_chapter_critique,
     parse_chapter_plan,
     parse_continuity_update,
+    parse_developmental_rewrite_plan,
     parse_manuscript_qa_report,
     parse_outline,
     parse_story_bible,
@@ -677,6 +679,90 @@ def test_manuscript_qa_parser_coerces_scalar_note_fields() -> None:
     assert report.genre_contract_notes == [
         "The selected sci-fi thriller contract is present, but the ending promise needs sharper pressure."
     ]
+
+
+def test_developmental_rewrite_parser_accepts_wrapped_plan() -> None:
+    plan = parse_developmental_rewrite_plan(
+        """
+        {
+          "developmental_rewrite_plan": {
+            "overall_diagnosis": "The middle repeats the same alarm loop.",
+            "act_structure_notes": "Act II needs a non-technical consequence.",
+            "chapter_actions": [
+              {
+                "chapter_numbers": "1, 2",
+                "action": "merge",
+                "reason": "Both chapters perform the same access-and-lockout beat.",
+                "required_story_change": "Collapse the duplicated breach into one civilian-facing reversal.",
+                "permanent_consequence": "Iris loses shelter access."
+              }
+            ],
+            "merge_candidates": ["Chapters 1-2"],
+            "cut_candidates": [],
+            "continuity_repairs": [],
+            "theme_arc_repairs": [],
+            "prose_pattern_repairs": ["Remove repeated future-hangs phrasing."],
+            "pre_rewrite_risks": ["Repeated alarm loop."],
+            "post_rewrite_risk_targets": ["One merged chapter creates a unique consequence."]
+          }
+        }
+        """
+    )
+
+    assert plan.chapter_actions[0].chapter_numbers == [1, 2]
+    assert plan.chapter_actions[0].action == "merge"
+    assert plan.act_structure_notes == ["Act II needs a non-technical consequence."]
+    assert plan.post_rewrite_risk_targets == ["One merged chapter creates a unique consequence."]
+
+
+def test_developmental_rewrite_prompt_includes_full_manuscript_and_qa() -> None:
+    project = Project(
+        title="The Glass Orchard",
+        premise="An archivist finds a living map under a failing city.",
+        desired_word_count=2000,
+        requested_chapters=1,
+        min_words_per_chapter=900,
+        max_words_per_chapter=1200,
+        preferred_model="test-model",
+        story_brief={},
+    )
+    chapter = ChapterDraft(
+        chapter_number=1,
+        title="Signal",
+        outline_summary="Iris follows the map.",
+        content="Chapter 1: Signal\n\nIris follows the map. Tarin refuses the easy route.",
+        summary="Iris follows the map.",
+        qa_notes={"repetition_risk_score": 7},
+    )
+    chapter.continuity_update = {
+        "story_turn": {
+            "irreversible_change": "Iris burns the archive key.",
+            "protagonist_choice": "Iris chooses entry over permission.",
+            "permanent_consequence": "The lower stair stays open.",
+        }
+    }
+    qa_report = parse_manuscript_qa_report(
+        """
+        {
+          "overall_verdict": "The manuscript is coherent but repetitive.",
+          "repetition_risks": ["The first act repeats access-and-warning beats."]
+        }
+        """
+    )
+
+    messages = build_developmental_rewrite_messages(
+        project,
+        {"logline": "A map wakes.", "genre_profile": "sci_fi_thriller"},
+        {"current_patch_status": "No repair yet."},
+        qa_report,
+        [chapter],
+    )
+    prompt = messages[-1]["content"]
+
+    assert "Full manuscript chapters" in prompt
+    assert "Iris follows the map. Tarin refuses the easy route." in prompt
+    assert "pre_rewrite_risks" in prompt
+    assert "post_rewrite_risk_targets" in prompt
 
 
 def test_prompt_builders_include_prose_voice_profile() -> None:

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -672,6 +672,8 @@ def test_project_run_setup_warns_for_external_default_provider(client, monkeypat
     assert "This route may send manuscript text and story data to the configured external provider." in response.text
     assert "Full novel runs can use large prompts" in response.text
     assert "Chapter draft: OpenAI-compatible API" in response.text
+    assert "Run developmental rewrite planning" in response.text
+    assert "Developmental rewrite: OpenAI-compatible API" in response.text
 
 
 def test_run_detail_warns_for_external_provider_routes(client, monkeypatch) -> None:


### PR DESCRIPTION
## What changed

- Added an optional per-run developmental rewrite stage after manuscript QA and before export.
- Added structured developmental rewrite schemas, prompt builder/parser, and fallback deterministic planning when model output is unusable.
- Export enabled runs with a developmental rewrite report, revised-outline artifact, and developmental QA comparison report.
- Added a run form toggle, progress-stage metadata, provider routing support for the new stage, and a DB migration for the run-level flag.
- Added tests for API rerun preservation, prompt parsing/building, export artifacts, pipeline execution, and UI visibility.

Fixes #11.

## Validation

- `git diff --check`
- `git diff --cached --check`
- Could not run pytest locally: the visible venv is Python 3.7/broken while the project requires Python >=3.11, and Docker Desktop could not be started from this session.