### PR TITLE
[codex] Add continuity bible validation

### DIFF
--- a/src/novel_generator/schemas.py
+++ b/src/novel_generator/schemas.py
@@ -291,6 +291,46 @@ class StructuredOutlineEntry(BaseModel):
         return normalize_chapter_mode(value)
 
 
+class SystemStateTransition(BaseModel):
+    system_name: str = ""
+    previous_state: str = ""
+    new_state: str = ""
+    cause: str = ""
+    chapter_number: int = 0
+
+    @field_validator("system_name", "previous_state", "new_state", "cause", mode="before")
+    @classmethod
+    def validate_transition_strings(cls, value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+    @field_validator("chapter_number", mode="before")
+    @classmethod
+    def validate_chapter_number(cls, value: Any) -> int:
+        if value in (None, ""):
+            return 0
+        try:
+            return max(0, int(value))
+        except (TypeError, ValueError):
+            return 0
+
+
+class ContinuityBibleRow(BaseModel):
+    item_type: str = ""
+    name: str = ""
+    canon_status: str = ""
+    observed_status: str = ""
+    notes: str = ""
+
+    @field_validator("item_type", "name", "canon_status", "observed_status", "notes", mode="before")
+    @classmethod
+    def validate_row_strings(cls, value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
+
+
 class ContinuityLedger(BaseModel):
     current_patch_status: str
     character_states: dict[str, str] = Field(default_factory=dict)
@@ -308,11 +348,24 @@ class ContinuityLedger(BaseModel):
     emotional_open_loops: dict[str, str] = Field(default_factory=dict)
     side_character_decisions: dict[str, list[str]] = Field(default_factory=dict)
     genre_state: dict[str, str] = Field(default_factory=dict)
+    system_state_by_name: dict[str, str] = Field(default_factory=dict)
+    system_state_transitions: list[SystemStateTransition] = Field(default_factory=list)
 
     @field_validator("side_character_decisions", mode="before")
     @classmethod
     def validate_side_character_decisions(cls, value: Any) -> dict[str, list[str]]:
         return _clean_list_map(value)
+
+    @field_validator("system_state_transitions", mode="before")
+    @classmethod
+    def validate_system_state_transitions(cls, value: Any) -> list[Any]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            return [value]
+        return []
 
 
 class ChapterStoryTurn(BaseModel):
@@ -398,6 +451,7 @@ class ChapterContinuityUpdate(BaseModel):
     side_character_decisions: dict[str, list[str]] = Field(default_factory=dict)
     story_turn: "ChapterStoryTurn" = Field(default_factory=lambda: ChapterStoryTurn())
     genre_state: dict[str, str] = Field(default_factory=dict)
+    system_state_transitions: list[SystemStateTransition] = Field(default_factory=list)
 
     @field_validator(
         "open_threads",
@@ -414,6 +468,17 @@ class ChapterContinuityUpdate(BaseModel):
     @classmethod
     def validate_side_character_decisions(cls, value: Any) -> dict[str, list[str]]:
         return _clean_list_map(value)
+
+    @field_validator("system_state_transitions", mode="before")
+    @classmethod
+    def validate_system_state_transitions(cls, value: Any) -> list[Any]:
+        if value is None:
+            return []
+        if isinstance(value, list):
+            return value
+        if isinstance(value, dict):
+            return [value]
+        return []
 
 
 class ChapterCritique(BaseModel):
@@ -536,6 +601,8 @@ class ManuscriptQaReport(BaseModel):
     scene_mode_distribution_notes: list[str] = Field(default_factory=list)
     story_turn_quality_notes: list[str] = Field(default_factory=list)
     genre_contract_notes: list[str] = Field(default_factory=list)
+    continuity_bible_findings: list[str] = Field(default_factory=list)
+    continuity_bible_table: list[ContinuityBibleRow] = Field(default_factory=list)
 
     @field_validator("overall_verdict", mode="before")
     @classmethod
@@ -563,11 +630,33 @@ class ManuscriptQaReport(BaseModel):
         "scene_mode_distribution_notes",
         "story_turn_quality_notes",
         "genre_contract_notes",
+        "continuity_bible_findings",
         mode="before",
     )
     @classmethod
     def validate_report_lists(cls, value: Any) -> list[str]:
         return _clean_list(value)
+
+    @field_validator("continuity_bible_table", mode="before")
+    @classmethod
+    def validate_continuity_bible_table(cls, value: Any) -> list[Any]:
+        if value is None:
+            return []
+        if isinstance(value, str):
+            rendered = value.strip()
+            return [{"item_type": "note", "name": rendered, "notes": rendered}] if rendered else []
+        if isinstance(value, dict):
+            return [value]
+        if isinstance(value, list):
+            rows: list[Any] = []
+            for item in value:
+                if isinstance(item, dict):
+                    rows.append(item)
+                elif str(item).strip():
+                    rendered = str(item).strip()
+                    rows.append({"item_type": "note", "name": rendered, "notes": rendered})
+            return rows
+        return []
 
 
 class DevelopmentalChapterAction(BaseModel):

--- a/src/novel_generator/schemas.py
+++ b/src/novel_generator/schemas.py
@@ -642,6 +642,10 @@ class ManuscriptQaReport(BaseModel):
     def validate_continuity_bible_table(cls, value: Any) -> list[Any]:
         if value is None:
             return []
+        if isinstance(value, ContinuityBibleRow):
+            return [value.model_dump()]
+        if isinstance(value, BaseModel):
+            return [value.model_dump()]
         if isinstance(value, str):
             rendered = value.strip()
             return [{"item_type": "note", "name": rendered, "notes": rendered}] if rendered else []
@@ -650,7 +654,11 @@ class ManuscriptQaReport(BaseModel):
         if isinstance(value, list):
             rows: list[Any] = []
             for item in value:
-                if isinstance(item, dict):
+                if isinstance(item, ContinuityBibleRow):
+                    rows.append(item.model_dump())
+                elif isinstance(item, BaseModel):
+                    rows.append(item.model_dump())
+                elif isinstance(item, dict):
                     rows.append(item)
                 elif str(item).strip():
                     rendered = str(item).strip()

--- a/src/novel_generator/services/editorial.py
+++ b/src/novel_generator/services/editorial.py
@@ -42,6 +42,29 @@ STORY_TURN_REQUIRED_FIELDS = (
     "state_after",
 )
 
+PRONOUN_GROUPS = {
+    "she/her": {"she", "her", "hers"},
+    "he/him": {"he", "him", "his"},
+    "they/them": {"they", "them", "their", "theirs"},
+}
+
+ROLE_DRIFT_MARKERS = {
+    "ally",
+    "antagonist",
+    "archivist",
+    "captain",
+    "doctor",
+    "enemy",
+    "engineer",
+    "guardian",
+    "leader",
+    "mentor",
+    "pilot",
+    "scientist",
+    "traitor",
+    "villain",
+}
+
 ABSTRACT_STORY_TURN_PATTERNS = [
     r"\bstakes? (?:rise|increase|escalate)\b",
     r"\bthe story (?:moves|pushes|continues|goes) forward\b",
@@ -985,6 +1008,312 @@ def _sentences_with_name(text: str, name: str) -> list[str]:
     return [sentence for sentence in _sentences(text) if _mentions_name(sentence, name)]
 
 
+def _payload_role(item: Any) -> str:
+    if isinstance(item, dict):
+        return str(item.get("role", "")).strip()
+    return str(getattr(item, "role", "")).strip()
+
+
+def _chapter_continuity_update(chapter: ChapterDraft) -> dict[str, Any]:
+    update = chapter.continuity_update or {}
+    if isinstance(update, dict):
+        return update
+    return getattr(update, "model_dump", lambda: {})()
+
+
+def _canon_character_roles(story_bible: StoryBible | dict[str, Any]) -> dict[str, str]:
+    bible = story_bible if isinstance(story_bible, dict) else story_bible.model_dump()
+    roles: dict[str, str] = {}
+    for member in bible.get("cast") or []:
+        name = _payload_name(member)
+        role = _payload_role(member)
+        if name:
+            roles[name] = role
+    for entity in bible.get("canon_registry") or []:
+        if str(entity.get("kind", "")).strip().lower() != "person":
+            continue
+        name = _payload_name(entity)
+        role = _payload_role(entity)
+        if name and role:
+            roles.setdefault(name, role)
+    return roles
+
+
+def _canon_system_roles(story_bible: StoryBible | dict[str, Any]) -> dict[str, str]:
+    bible = story_bible if isinstance(story_bible, dict) else story_bible.model_dump()
+    systems: dict[str, str] = {}
+    for entity in bible.get("canon_registry") or []:
+        if str(entity.get("kind", "")).strip().lower() not in {"system", "project"}:
+            continue
+        name = _payload_name(entity)
+        role = _payload_role(entity)
+        if name:
+            systems[name] = role or "Core system or project in canon registry."
+    return systems
+
+
+def _name_similarity_key(name: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", name.lower())
+
+
+def _levenshtein_distance(left: str, right: str) -> int:
+    if left == right:
+        return 0
+    if not left:
+        return len(right)
+    if not right:
+        return len(left)
+    previous = list(range(len(right) + 1))
+    for left_index, left_char in enumerate(left, start=1):
+        current = [left_index]
+        for right_index, right_char in enumerate(right, start=1):
+            insertion = current[right_index - 1] + 1
+            deletion = previous[right_index] + 1
+            substitution = previous[right_index - 1] + (left_char != right_char)
+            current.append(min(insertion, deletion, substitution))
+        previous = current
+    return previous[-1]
+
+
+def _names_are_confusable(left: str, right: str) -> bool:
+    left_key = _name_similarity_key(left)
+    right_key = _name_similarity_key(right)
+    if not left_key or not right_key or left_key == right_key:
+        return False
+    shorter = min(len(left_key), len(right_key))
+    if shorter < 4:
+        return _levenshtein_distance(left_key, right_key) <= 1
+    distance = _levenshtein_distance(left_key, right_key)
+    if distance <= (2 if shorter <= 6 else 3):
+        return True
+    return left_key[:4] == right_key[:4] and abs(len(left_key) - len(right_key)) <= 3
+
+
+def _pronoun_group_from_text(text: str) -> str:
+    lowered = text.lower()
+    for group in PRONOUN_GROUPS:
+        if group in lowered:
+            return group
+    words = _normalized_words(text)
+    counts = Counter(
+        group
+        for group, pronouns in PRONOUN_GROUPS.items()
+        for word in words
+        if word in pronouns
+    )
+    if not counts:
+        return ""
+    dominant, count = counts.most_common(1)[0]
+    if len(counts) > 1 and counts.most_common(2)[1][1] == count:
+        return ""
+    return dominant
+
+
+def _pronoun_group_near_name(chapter: ChapterDraft, name: str) -> str:
+    sentences = _sentences(chapter.content or "")
+    snippets: list[str] = []
+    for index, sentence in enumerate(sentences):
+        if not _mentions_name(sentence, name):
+            continue
+        snippets.append(sentence)
+        if index + 1 < len(sentences):
+            snippets.append(sentences[index + 1])
+    return _pronoun_group_from_text(" ".join(snippets))
+
+
+def _role_terms(text: str) -> set[str]:
+    return {word for word in _normalized_words(text) if word in ROLE_DRIFT_MARKERS}
+
+
+def _role_has_drift(canon_role: str, observed_role: str) -> bool:
+    observed_terms = _role_terms(observed_role)
+    if not observed_terms:
+        return False
+    canon_terms = _role_terms(canon_role)
+    return not bool(canon_terms & observed_terms)
+
+
+def _transition_payload(transition: Any) -> dict[str, Any]:
+    if isinstance(transition, dict):
+        return transition
+    return getattr(transition, "model_dump", lambda: {})()
+
+
+def _transition_system_name(transition: Any) -> str:
+    return str(_transition_payload(transition).get("system_name", "")).strip()
+
+
+def _continuity_bible_notes(
+    chapters: list[ChapterDraft],
+    story_bible: StoryBible | dict[str, Any],
+) -> tuple[list[str], list[dict[str, str]]]:
+    character_roles = _canon_character_roles(story_bible)
+    system_roles = _canon_system_roles(story_bible)
+    findings: list[str] = []
+    rows: list[dict[str, str]] = []
+
+    names = list(dict.fromkeys([*character_roles.keys(), *system_roles.keys()]))
+    for index, left in enumerate(names):
+        for right in names[index + 1 :]:
+            if _names_are_confusable(left, right):
+                findings.append(
+                    f"Continuity bible name collision: '{left}' and '{right}' are visually or phonetically similar; suggested rename one with a distinct first syllable before export."
+                )
+
+    pronouns_by_character: dict[str, dict[str, list[int]]] = {
+        name: {}
+        for name in character_roles
+    }
+    latest_character_state: dict[str, str] = {}
+    system_state_by_name: dict[str, str] = dict(system_roles)
+    transition_counts: Counter[str] = Counter()
+    sorted_chapters = sorted(chapters, key=lambda item: item.chapter_number)
+
+    for chapter in sorted_chapters:
+        update = _chapter_continuity_update(chapter)
+        character_states = update.get("character_states", {}) if isinstance(update.get("character_states", {}), dict) else {}
+        for name, canon_role in character_roles.items():
+            prose_group = _pronoun_group_near_name(chapter, name)
+            state_text = str(character_states.get(name, "")).strip()
+            state_group = _pronoun_group_from_text(state_text)
+            group = state_group or prose_group
+            if group:
+                pronouns_by_character.setdefault(name, {}).setdefault(group, []).append(chapter.chapter_number)
+            if state_text:
+                latest_character_state[name] = state_text
+                if _role_has_drift(canon_role, state_text):
+                    findings.append(
+                        f"Continuity bible role drift: {name} is canonically '{canon_role}' but chapter {chapter.chapter_number} records '{state_text}' without a canon-fix note."
+                    )
+
+        for entity in update.get("new_entities_introduced", []) or []:
+            if str(entity.get("kind", "")).strip().lower() != "person":
+                continue
+            name = _payload_name(entity)
+            if name in character_roles and _role_has_drift(character_roles[name], _payload_role(entity)):
+                findings.append(
+                    f"Continuity bible role drift: {name} is canonically '{character_roles[name]}' but chapter {chapter.chapter_number} reintroduces them as '{_payload_role(entity)}'."
+                )
+
+        transitions = [_transition_payload(item) for item in update.get("system_state_transitions", []) or []]
+        transition_names = {_transition_system_name(item) for item in transitions if _transition_system_name(item)}
+        for transition in transitions:
+            system_name = str(transition.get("system_name", "")).strip()
+            previous_state = str(transition.get("previous_state", "")).strip()
+            new_state = str(transition.get("new_state", "")).strip()
+            cause = str(transition.get("cause", "")).strip()
+            if not (system_name and previous_state and new_state and cause):
+                findings.append(
+                    f"Continuity bible system-state warning: chapter {chapter.chapter_number} has an incomplete system_state_transition for '{system_name or 'unnamed system'}'."
+                )
+                continue
+            prior_state = system_state_by_name.get(system_name, "")
+            if prior_state and previous_state.lower() != prior_state.lower():
+                findings.append(
+                    f"Continuity bible system-state mismatch: chapter {chapter.chapter_number} moves '{system_name}' from '{previous_state}', but the prior tracked state is '{prior_state}'."
+                )
+            system_state_by_name[system_name] = new_state
+            transition_counts[system_name] += 1
+
+        entity_state_changes = update.get("entity_state_changes", {})
+        if isinstance(entity_state_changes, dict):
+            for system_name in system_roles:
+                if system_name in entity_state_changes and system_name not in transition_names:
+                    findings.append(
+                        f"Continuity bible system-state warning: chapter {chapter.chapter_number} changes core system '{system_name}' without a structured system_state_transition."
+                    )
+
+    for name, groups in pronouns_by_character.items():
+        if len(groups) <= 1:
+            continue
+        rendered = ", ".join(
+            f"{group} in chapter(s) {', '.join(str(number) for number in numbers)}"
+            for group, numbers in groups.items()
+        )
+        findings.append(
+            f"Continuity bible pronoun drift: {name} uses inconsistent pronouns across the manuscript: {rendered}."
+        )
+
+    for name, role in character_roles.items():
+        groups = pronouns_by_character.get(name, {})
+        pronoun_note = ", ".join(groups) if groups else "No pronoun evidence captured."
+        rows.append(
+            {
+                "item_type": "character",
+                "name": name,
+                "canon_status": role or "No canon role recorded.",
+                "observed_status": latest_character_state.get(name, "No stored character state recorded."),
+                "notes": pronoun_note,
+            }
+        )
+
+    for name, canon_state in system_roles.items():
+        transition_count = transition_counts.get(name, 0)
+        rows.append(
+            {
+                "item_type": "system",
+                "name": name,
+                "canon_status": canon_state,
+                "observed_status": system_state_by_name.get(name, "No structured system state recorded."),
+                "notes": f"{transition_count} structured transition(s) recorded.",
+            }
+        )
+
+    return findings, rows
+
+
+def _dedupe_continuity_bible_rows(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    unique: list[dict[str, str]] = []
+    seen: set[tuple[str, str, str, str, str]] = set()
+    for row in rows:
+        key = (
+            row.get("item_type", ""),
+            row.get("name", ""),
+            row.get("canon_status", ""),
+            row.get("observed_status", ""),
+            row.get("notes", ""),
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(row)
+    return unique
+
+
+def _qa_row_value(row: Any, field_name: str) -> str:
+    if isinstance(row, dict):
+        return str(row.get(field_name, "")).strip()
+    return str(getattr(row, field_name, "")).strip()
+
+
+def _markdown_cell(value: str) -> str:
+    return value.replace("|", "\\|") or " "
+
+
+def _render_continuity_bible_table(rows: list[Any]) -> list[str]:
+    if not rows:
+        return ["- No continuity bible table recorded."]
+    rendered = [
+        "| Type | Name | Canon Status | Observed Status | Notes |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        rendered.append(
+            "| "
+            + " | ".join(
+                [
+                    _markdown_cell(_qa_row_value(row, "item_type")),
+                    _markdown_cell(_qa_row_value(row, "name")),
+                    _markdown_cell(_qa_row_value(row, "canon_status")),
+                    _markdown_cell(_qa_row_value(row, "observed_status")),
+                    _markdown_cell(_qa_row_value(row, "notes")),
+                ]
+            )
+            + " |"
+        )
+    return rendered
+
+
 def _has_side_character_action(sentences: list[str]) -> bool:
     for sentence in sentences:
         terms = set(_normalized_words(sentence))
@@ -1738,6 +2067,8 @@ def manuscript_quality_notes(
         "scene_mode_distribution_notes": [],
         "story_turn_quality_notes": [],
         "genre_contract_notes": [],
+        "continuity_bible_findings": [],
+        "continuity_bible_table": [],
     }
 
     manuscript_text = "\n\n".join(chapter.content or "" for chapter in chapters).lower()
@@ -1937,6 +2268,9 @@ def manuscript_quality_notes(
                 notes["proper_noun_continuity_findings"].append(
                     f"Alias drift risk: aliases for '{name}' appear without the canonical name."
                 )
+        continuity_bible_findings, continuity_bible_rows = _continuity_bible_notes(chapters, bible)
+        notes["continuity_bible_findings"].extend(continuity_bible_findings)
+        notes["continuity_bible_table"].extend(continuity_bible_rows)
 
     notes["chapter_ending_quality_notes"] = list(dict.fromkeys(notes["chapter_ending_quality_notes"]))
     notes["easy_win_warnings"] = list(dict.fromkeys(notes["easy_win_warnings"]))
@@ -1951,6 +2285,8 @@ def manuscript_quality_notes(
     notes["scene_mode_distribution_notes"] = list(dict.fromkeys(notes["scene_mode_distribution_notes"]))
     notes["story_turn_quality_notes"] = list(dict.fromkeys(notes["story_turn_quality_notes"]))
     notes["genre_contract_notes"] = list(dict.fromkeys(notes["genre_contract_notes"]))
+    notes["continuity_bible_findings"] = list(dict.fromkeys(notes["continuity_bible_findings"]))
+    notes["continuity_bible_table"] = _dedupe_continuity_bible_rows(notes["continuity_bible_table"])
     return notes
 
 
@@ -1971,6 +2307,14 @@ def render_qa_report_markdown(report: ManuscriptQaReport) -> str:
         "## Continuity Risks",
         "",
         *([f"- {item}" for item in report.continuity_risks] or ["- No continuity risks recorded."]),
+        "",
+        "## Continuity Bible Findings",
+        "",
+        *([f"- {item}" for item in report.continuity_bible_findings] or ["- No continuity bible findings recorded."]),
+        "",
+        "## Continuity Bible Table",
+        "",
+        *_render_continuity_bible_table(report.continuity_bible_table),
         "",
         "## Repetition Risks",
         "",
@@ -2101,6 +2445,7 @@ def render_developmental_rewrite_report_markdown(
                     *qa_report.warnings,
                     *qa_report.repetition_risks,
                     *qa_report.continuity_risks,
+                    *qa_report.continuity_bible_findings,
                     *qa_report.crisis_loop_findings,
                 ]
             ]
@@ -2128,6 +2473,7 @@ def render_developmental_qa_comparison_markdown(
             *qa_report.chapter_ending_quality_notes,
             *qa_report.technical_escalation_fatigue_findings,
             *qa_report.crisis_loop_findings,
+            *qa_report.continuity_bible_findings,
             *qa_report.story_turn_quality_notes,
         ]
     )

--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -14,6 +14,7 @@ from ..schemas import (
     ChapterCritique,
     ChapterPlan,
     CanonicalEntity,
+    ContinuityBibleRow,
     ContinuityLedger,
     DevelopmentalRewritePlan,
     ManuscriptQaReport,
@@ -69,6 +70,25 @@ class RunCanceled(Exception):
 
 def _dedupe(items: list[str]) -> list[str]:
     return list(dict.fromkeys(item for item in items if item))
+
+
+def _dedupe_continuity_bible_table(rows: list[Any]) -> list[ContinuityBibleRow]:
+    unique: list[ContinuityBibleRow] = []
+    seen: set[tuple[str, str, str, str, str]] = set()
+    for row in rows:
+        payload = row if isinstance(row, ContinuityBibleRow) else ContinuityBibleRow.model_validate(row)
+        key = (
+            payload.item_type,
+            payload.name,
+            payload.canon_status,
+            payload.observed_status,
+            payload.notes,
+        )
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(payload)
+    return unique
 
 
 def _project_approved_canon(project: Any) -> list[dict[str, Any]]:
@@ -228,6 +248,11 @@ def _resolve_stage_route(
 
 def _build_initial_ledger(story_bible: StoryBible) -> ContinuityLedger:
     profile = genre_profile(story_bible.genre_profile)
+    system_state_by_name = {
+        entity.name: entity.role or "Defined in canon registry; initial state not yet changed on page."
+        for entity in story_bible.canon_registry
+        if entity.name and entity.kind.lower() in {"system", "project"}
+    }
     return ContinuityLedger(
         current_patch_status="No irreversible patch decision has been made yet.",
         character_states={
@@ -258,6 +283,8 @@ def _build_initial_ledger(story_bible: StoryBible) -> ContinuityLedger:
         },
         side_character_decisions={},
         genre_state=dict(profile.default_genre_state),
+        system_state_by_name=system_state_by_name,
+        system_state_transitions=[],
     )
 
 
@@ -299,6 +326,16 @@ def _ledger_from_update(current_ledger: ContinuityLedger, update: ChapterContinu
         existing = side_character_decisions.get(name, [])
         side_character_decisions[name] = _dedupe([*existing, *moves])
 
+    system_state_by_name = dict(current_ledger.system_state_by_name)
+    system_state_transitions = list(current_ledger.system_state_transitions)
+    for transition in update.system_state_transitions:
+        if transition.system_name:
+            system_state_by_name[transition.system_name] = transition.new_state or system_state_by_name.get(
+                transition.system_name,
+                "",
+            )
+        system_state_transitions.append(transition)
+
     return ContinuityLedger(
         current_patch_status=update.current_patch_status or current_ledger.current_patch_status,
         character_states={**current_ledger.character_states, **update.character_states},
@@ -316,6 +353,8 @@ def _ledger_from_update(current_ledger: ContinuityLedger, update: ChapterContinu
         emotional_open_loops={**current_ledger.emotional_open_loops, **update.emotional_open_loops},
         side_character_decisions=side_character_decisions,
         genre_state={**current_ledger.genre_state, **update.genre_state},
+        system_state_by_name=system_state_by_name,
+        system_state_transitions=system_state_transitions,
     )
 
 
@@ -860,6 +899,12 @@ def _run_manuscript_qa(
             "genre_contract_notes": _dedupe(
                 [*qa_report.genre_contract_notes, *deterministic_notes["genre_contract_notes"]]
             ),
+            "continuity_bible_findings": _dedupe(
+                [*qa_report.continuity_bible_findings, *deterministic_notes["continuity_bible_findings"]]
+            ),
+            "continuity_bible_table": _dedupe_continuity_bible_table(
+                [*qa_report.continuity_bible_table, *deterministic_notes["continuity_bible_table"]]
+            ),
         }
     )
     qa_markdown = render_qa_report_markdown(qa_report)
@@ -880,6 +925,7 @@ def _fallback_developmental_rewrite_plan(
             *qa_report.crisis_loop_findings,
             *qa_report.scene_mode_distribution_notes,
             *qa_report.story_turn_quality_notes,
+            *qa_report.continuity_bible_findings,
         ]
     )
     chapter_actions = []

--- a/src/novel_generator/services/prompts.py
+++ b/src/novel_generator/services/prompts.py
@@ -789,7 +789,16 @@ def build_continuity_update_messages(
                 '    "state_before": "concrete state before the chapter",\n'
                 '    "state_after": "concrete state after the chapter"\n'
                 "  },\n"
-                '  "genre_state": {"profile state key": "current state after this chapter"}\n'
+                '  "genre_state": {"profile state key": "current state after this chapter"},\n'
+                '  "system_state_transitions": [\n'
+                "    {\n"
+                '      "system_name": "core system or project name",\n'
+                '      "previous_state": "state before this chapter",\n'
+                '      "new_state": "state after this chapter",\n'
+                '      "cause": "on-page cause of the state change",\n'
+                '      "chapter_number": 1\n'
+                "    }\n"
+                "  ]\n"
                 "}\n\n"
                 "Rules:\n"
                 "- keep unresolved threads alive unless the chapter truly resolves them\n"
@@ -802,6 +811,8 @@ def build_continuity_update_messages(
                 "- track major side-character decisions when a non-protagonist takes an independent action that changes the protagonist's options\n"
                 "- story_turn must summarize the actual irreversible change, protagonist choice, rejected alternatives, permanent consequence, and before/after manuscript state created by this chapter\n"
                 "- update genre_state using the selected profile's continuity focus and default_genre_state\n"
+                "- for every major system or project state change, add one system_state_transitions item with previous_state matching the current ledger when known, a new_state, and an on-page cause\n"
+                "- do not hide system removals, dormancy, reactivation, compromise, or governance changes in prose-only summaries\n"
                 "- include profile-specific continuity focus: "
                 + "; ".join(profile.continuity_focus)
             ),
@@ -823,6 +834,7 @@ def build_manuscript_qa_messages(
             "title": chapter.title,
             "summary": chapter.summary or "",
             "word_count": chapter.word_count,
+            "continuity_update": _chapter_continuity_payload(chapter),
             "story_turn": _chapter_continuity_payload(chapter).get("story_turn", {}),
             "qa_notes": chapter.qa_notes or {},
         }
@@ -864,10 +876,20 @@ def build_manuscript_qa_messages(
                 '  "crisis_loop_findings": ["string"],\n'
                 '  "scene_mode_distribution_notes": ["string"],\n'
                 '  "story_turn_quality_notes": ["string"],\n'
-                '  "genre_contract_notes": ["string"]\n'
+                '  "genre_contract_notes": ["string"],\n'
+                '  "continuity_bible_findings": ["inconsistent character facts, similar names, missing system transitions, or canon fixes"],\n'
+                '  "continuity_bible_table": [\n'
+                "    {\n"
+                '      "item_type": "character|system",\n'
+                '      "name": "canon name",\n'
+                '      "canon_status": "role or starting state from the bible",\n'
+                '      "observed_status": "latest manuscript state",\n'
+                '      "notes": "pronoun, role, name, or state-machine note"\n'
+                "    }\n"
+                "  ]\n"
                 "}\n\n"
                 "Be specific about repeated setups, duplicated endings, abstract or outline-summary endings, continuity instability, easy technical wins, side-character flatness, "
-                "meta/outlining language in chapter prose, chapter_mode distribution and adjacent mode repetition, story_turn quality, cuttable chapters, duplicated irreversible turns, proper-noun drift, emotional pacing, ideology blur, civilian-life absence, repeated crisis loops with chapter numbers, exact beat patterns, representative phrases, severity, and suggested structural fixes, repeated emergency mechanics such as lockdown, quarantine, reboot, alarm, warning banner, reserve drain, core temperature, critical failure, drone breach, override, or countdown, and whether the manuscript delivers on the ending promise. "
+                "meta/outlining language in chapter prose, chapter_mode distribution and adjacent mode repetition, story_turn quality, cuttable chapters, duplicated irreversible turns, proper-noun drift, emotional pacing, ideology blur, civilian-life absence, repeated crisis loops with chapter numbers, exact beat patterns, representative phrases, severity, and suggested structural fixes, repeated emergency mechanics such as lockdown, quarantine, reboot, alarm, warning banner, reserve drain, core temperature, critical failure, drone breach, override, or countdown, continuity-bible risks such as character pronoun or role drift, confusingly similar names with suggested renames, and unexplained core-system state transitions, and whether the manuscript delivers on the ending promise. "
                 "Genre contract notes must judge the selected profile: "
                 + "; ".join(profile.qa_focus or profile.genre_contract)
             ),

--- a/tests/test_editorial.py
+++ b/tests/test_editorial.py
@@ -560,6 +560,49 @@ def test_manuscript_quality_notes_tracks_side_character_decision_coverage() -> N
     assert any("Major side character Nadia has only 1 tracked independent decision" in item for item in notes["side_character_agency_notes"])
 
 
+def test_manuscript_quality_notes_builds_continuity_bible_findings() -> None:
+    bible = {
+        **_story_bible(),
+        "cast": [
+            *_story_bible()["cast"],
+            {"name": "Lila", "role": "Courier", "desire": "Carry proof", "risk": "Being erased"},
+            {"name": "Lina", "role": "Medic", "desire": "Keep civilians alive", "risk": "Losing triage access"},
+        ],
+    }
+    first = ChapterDraft(
+        chapter_number=1,
+        title="Signal",
+        outline_summary="Mara discovers the patch.",
+        content="Mara sealed the hatch. She refused the watchdog's quiet bargain.",
+        status=ChapterStatus.COMPLETED,
+    )
+    first.continuity_update = {
+        "character_states": {"Mara": "Pronouns: she/her. Engineer still chasing the forged patch."},
+        "entity_state_changes": {"Harmony Watchdog": "It shifts from passive monitor to active blocker."},
+    }
+    second = ChapterDraft(
+        chapter_number=2,
+        title="Watchdog",
+        outline_summary="Mara proves the patch is manipulating compliance.",
+        content="Mara opened the vault. He ordered Nadia to purge the records.",
+        status=ChapterStatus.COMPLETED,
+    )
+    second.continuity_update = {
+        "character_states": {"Mara": "Pronouns: he/him. Now acting as antagonist to the archive."},
+    }
+
+    notes = manuscript_quality_notes([first, second], bible)
+
+    findings = " ".join(notes["continuity_bible_findings"])
+    assert "pronoun drift" in findings
+    assert "role drift" in findings
+    assert "name collision" in findings
+    assert "Lila" in findings and "Lina" in findings
+    assert "without a structured system_state_transition" in findings
+    assert any(row["item_type"] == "character" and row["name"] == "Mara" for row in notes["continuity_bible_table"])
+    assert any(row["item_type"] == "system" and row["name"] == "Harmony Watchdog" for row in notes["continuity_bible_table"])
+
+
 def test_lint_flags_prose_voice_and_style_avoid_problems() -> None:
     systems_outline = {**_outline_entry(), "chapter_mode": "systems_crisis"}
     style_plan = {

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -257,6 +257,15 @@ def _continuity_json(index: int) -> str:
             "civilian_pressure_points": [f"Civilian pressure {index}"],
             "emotional_open_loops": {"Iris": f"Emotional loop {index}"},
             "side_character_decisions": {"Tarin": [f"Tarin resists in chapter {index}"]},
+            "system_state_transitions": [
+                {
+                    "system_name": "Living Map",
+                    "previous_state": "Sentient guide lattice" if index == 1 else f"Map state {index - 1}",
+                    "new_state": f"Map state {index}",
+                    "cause": f"Chapter {index} forces the map to reveal a new route.",
+                    "chapter_number": index,
+                }
+            ],
             "story_turn": _story_turn_payload(index),
         }
     )
@@ -901,6 +910,8 @@ def test_continuity_ledger_carries_entities_forward_across_completed_chapters(co
         assert refreshed.continuity_ledger["trust_fractures"]["Iris/Tarin"] == "Trust fracture 2"
         assert refreshed.continuity_ledger["civilian_pressure_points"][-1] == "Civilian pressure 2"
         assert refreshed.continuity_ledger["side_character_decisions"]["Tarin"][-1].startswith("Tarin resists in chapter 2")
+        assert refreshed.continuity_ledger["system_state_by_name"]["Living Map"] == "Map state 2"
+        assert len(refreshed.continuity_ledger["system_state_transitions"]) == 2
 
 
 def test_v1_regeneration_creates_fresh_v2_structure(configured_environment) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from novel_generator.models import ChapterDraft, ChapterStatus, GenerationRun, Project
+from novel_generator.schemas import ContinuityBibleRow, ManuscriptQaReport
 from novel_generator.services.prompts import (
     build_chapter_critique_messages,
     build_chapter_draft_messages,
@@ -706,6 +707,24 @@ def test_manuscript_qa_parser_coerces_scalar_note_fields() -> None:
     assert report.genre_contract_notes == [
         "The selected sci-fi thriller contract is present, but the ending promise needs sharper pressure."
     ]
+
+
+def test_manuscript_qa_report_preserves_continuity_bible_row_instances() -> None:
+    row = ContinuityBibleRow(
+        item_type="system",
+        name="Living Map",
+        canon_status="Dormant guide lattice",
+        observed_status="Actively responding to Iris",
+        notes="1 structured transition recorded.",
+    )
+
+    report = ManuscriptQaReport.model_validate({"continuity_bible_table": [row]})
+
+    assert report.continuity_bible_table[0].item_type == "system"
+    assert report.continuity_bible_table[0].name == "Living Map"
+    assert report.continuity_bible_table[0].canon_status == "Dormant guide lattice"
+    assert report.continuity_bible_table[0].observed_status == "Actively responding to Iris"
+    assert report.continuity_bible_table[0].notes == "1 structured transition recorded."
 
 
 def test_manuscript_qa_prompt_requests_crisis_loop_findings() -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -6,6 +6,7 @@ from novel_generator.services.prompts import (
     build_chapter_draft_messages,
     build_chapter_plan_messages,
     build_chapter_revision_messages,
+    build_continuity_update_messages,
     build_developmental_rewrite_messages,
     build_manuscript_qa_messages,
     build_story_bible_messages,
@@ -577,6 +578,15 @@ def test_chapter_plan_critique_and_continuity_parsers_accept_richer_shapes() -> 
           "civilian_pressure_points": ["Families in the shelter lose archive access and heating."],
           "emotional_open_loops": {"Iris": "She fears she is choosing freedom with a damaged self."},
           "side_character_decisions": {"Tarin": ["Tarin blocks the elevator route until Iris gives him the source shard."]},
+          "system_state_transitions": [
+            {
+              "system_name": "Living Map",
+              "previous_state": "Hidden but active.",
+              "new_state": "Actively responding to Iris.",
+              "cause": "Iris burns her badge and speaks the map's buried name.",
+              "chapter_number": 1
+            }
+          ],
           "story_turn": {
             "irreversible_change": "Iris burns her badge and loses archive access.",
             "protagonist_choice": "Iris chooses to protect Tarin instead of preserving her credentials.",
@@ -612,6 +622,8 @@ def test_chapter_plan_critique_and_continuity_parsers_accept_richer_shapes() -> 
     assert continuity.genre_state["clue_chain"].startswith("The first planted clue")
     assert continuity.story_turn.permanent_consequence.startswith("Archive Security")
     assert continuity.side_character_decisions["Tarin"][0].startswith("Tarin blocks")
+    assert continuity.system_state_transitions[0].system_name == "Living Map"
+    assert continuity.system_state_transitions[0].new_state.startswith("Actively responding")
 
 
 def test_chapter_critique_parser_normalizes_percentage_style_scores() -> None:
@@ -672,6 +684,16 @@ def test_manuscript_qa_parser_coerces_scalar_note_fields() -> None:
           "overall_verdict": "The manuscript is coherent enough to export.",
           "warnings": "The middle needs one cleaner physical escalation.",
           "crisis_loop_findings": "Chapters 1, 2 repeat access -> warning -> lockout.",
+          "continuity_bible_findings": "Mara changes pronouns without a logged canon fix.",
+          "continuity_bible_table": [
+            {
+              "item_type": "character",
+              "name": "Mara",
+              "canon_status": "Engineer",
+              "observed_status": "Pronouns shift from she/her to he/him.",
+              "notes": "Needs canon decision."
+            }
+          ],
           "genre_contract_notes": "The selected sci-fi thriller contract is present, but the ending promise needs sharper pressure."
         }
         """
@@ -679,6 +701,8 @@ def test_manuscript_qa_parser_coerces_scalar_note_fields() -> None:
 
     assert report.warnings == ["The middle needs one cleaner physical escalation."]
     assert report.crisis_loop_findings == ["Chapters 1, 2 repeat access -> warning -> lockout."]
+    assert report.continuity_bible_findings == ["Mara changes pronouns without a logged canon fix."]
+    assert report.continuity_bible_table[0].name == "Mara"
     assert report.genre_contract_notes == [
         "The selected sci-fi thriller contract is present, but the ending promise needs sharper pressure."
     ]
@@ -701,15 +725,59 @@ def test_manuscript_qa_prompt_requests_crisis_loop_findings() -> None:
         outline_summary="Iris follows the map.",
         content="Iris enters a code. A warning starts a lockdown.",
         summary="Iris trips a warning loop.",
+        continuity_update={"system_state_transitions": []},
         status=ChapterStatus.COMPLETED,
     )
 
     prompt = build_manuscript_qa_messages(project, {"logline": "A map wakes."}, ["Repeated lockout."], [chapter])[-1]["content"]
 
     assert '"crisis_loop_findings"' in prompt
+    assert '"continuity_bible_findings"' in prompt
+    assert '"continuity_bible_table"' in prompt
+    assert '"system_state_transitions"' in prompt
     assert "representative phrases" in prompt
     assert "severity" in prompt
     assert "suggested structural fixes" in prompt
+    assert "suggested renames" in prompt
+    assert "unexplained core-system state transitions" in prompt
+
+
+def test_continuity_update_prompt_requests_system_state_transitions() -> None:
+    project = Project(
+        title="The Glass Orchard",
+        premise="An archivist finds a living map under a failing city.",
+        desired_word_count=2000,
+        requested_chapters=1,
+        min_words_per_chapter=900,
+        max_words_per_chapter=1200,
+        preferred_model="test-model",
+        story_brief={},
+    )
+    chapter = ChapterDraft(
+        chapter_number=1,
+        title="Signal",
+        outline_summary="Iris follows the map.",
+        summary="Iris wakes the Living Map.",
+        status=ChapterStatus.COMPLETED,
+    )
+    story_bible = {
+        "logline": "A map wakes.",
+        "genre_profile": "sci_fi_thriller",
+        "canon_registry": [
+            {"name": "Living Map", "kind": "system", "role": "Dormant guide lattice", "aliases": ["the map"]}
+        ],
+    }
+    ledger = {
+        "open_threads": ["Who built the map?"],
+        "active_entities": story_bible["canon_registry"],
+        "system_state_by_name": {"Living Map": "Dormant guide lattice"},
+    }
+
+    prompt = build_continuity_update_messages(project, chapter, ledger, story_bible)[-1]["content"]
+
+    assert '"system_state_transitions"' in prompt
+    assert '"previous_state"' in prompt
+    assert "previous_state matching the current ledger" in prompt
 
 
 def test_developmental_rewrite_parser_accepts_wrapped_plan() -> None:


### PR DESCRIPTION
## Summary
- add structured system state transitions to chapter continuity updates and the continuity ledger
- add continuity bible QA findings/table output for character identity, similar names, and core-system state validation
- merge deterministic continuity bible checks into manuscript QA and developmental rewrite risk inputs

Closes #13

## Validation
- `docker compose exec -T web python -m pytest tests/test_editorial.py tests/test_prompts.py tests/test_pipeline.py` (54 passed)
- `docker compose exec -T web python -m pytest` (100 passed)
- `git diff --check`
- `git diff --cached --check`