### PR TITLE
[codex] Fix large outline generation

### DIFF
--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -44,6 +44,7 @@ from .prompts import (
     build_chapter_draft_messages,
     build_chapter_plan_messages,
     build_chapter_revision_messages,
+    build_outline_chunk_messages,
     build_continuity_update_messages,
     build_developmental_rewrite_messages,
     build_json_repair_messages,
@@ -57,6 +58,7 @@ from .prompts import (
     parse_developmental_rewrite_plan,
     parse_manuscript_qa_report,
     parse_outline,
+    parse_outline_chunk,
     parse_story_bible,
     rolling_context,
     sanitize_chapter_content,
@@ -66,6 +68,10 @@ from .providers import ProviderManager
 
 class RunCanceled(Exception):
     pass
+
+
+OUTLINE_CHUNK_THRESHOLD = 32
+OUTLINE_CHUNK_SIZE = 8
 
 
 def _dedupe(items: list[str]) -> list[str]:
@@ -517,6 +523,231 @@ def _chapter_prior_context(run: GenerationRun, chapter_number: int) -> list:
     ]
 
 
+def _fallback_story_bible(project: Any, run: GenerationRun) -> StoryBible:
+    brief = project.story_brief or {}
+    profile = genre_profile(brief.get("genre_profile"))
+    protagonist = str(brief.get("protagonist") or "The protagonist").strip()
+    antagonist = str(brief.get("antagonist") or "the central opposition").strip()
+    supporting_cast = [
+        str(name).strip()
+        for name in brief.get("supporting_cast", [])
+        if str(name).strip()
+    ]
+    cast = [
+        {
+            "name": protagonist,
+            "role": "Protagonist",
+            "desire": brief.get("ending_target") or brief.get("core_conflict") or "Resolve the central conflict.",
+            "risk": "Losing agency, trust, or the chance to change the outcome.",
+        }
+    ]
+    for name in supporting_cast[:6]:
+        cast.append(
+            {
+                "name": name,
+                "role": "Supporting character",
+                "desire": "Push the protagonist toward a harder choice.",
+                "risk": "Paying a personal cost for the protagonist's progress.",
+            }
+        )
+
+    agendas = [
+        {
+            "name": member["name"],
+            "want": member["desire"],
+            "fear": member["risk"],
+            "line_in_sand": "They will not accept an easy solution that violates the story's moral boundary.",
+            "stance_on_core_conflict": brief.get("core_conflict") or "The central conflict must cost something real.",
+            "relationship_to_protagonist": "Self" if index == 0 else "Pressure-bearing ally or foil",
+            "public_belief": brief.get("core_conflict") or "The stated conflict must be confronted directly.",
+            "private_pressure": "They fear the final choice will cost more than they can admit.",
+            "stress_response": "They narrow into their strongest habit when pressure rises.",
+        }
+        for index, member in enumerate(cast)
+    ]
+    canon_registry = [
+        {
+            "name": protagonist,
+            "kind": "person",
+            "role": "Protagonist",
+            "aliases": [],
+            "approved": True,
+        }
+    ]
+    for name in supporting_cast[:6]:
+        canon_registry.append(
+            {
+                "name": name,
+                "kind": "person",
+                "role": "Supporting character",
+                "aliases": [],
+                "approved": True,
+            }
+        )
+    if antagonist:
+        canon_registry.append(
+            {
+                "name": antagonist,
+                "kind": "faction",
+                "role": "Primary opposition force",
+                "aliases": [],
+                "approved": True,
+            }
+        )
+
+    return StoryBible.model_validate(
+        {
+            "genre_profile": profile.id,
+            "logline": project.premise,
+            "theme": brief.get("core_conflict") or "Every victory should preserve a visible moral cost.",
+            "act_plan": [
+                "Act I establishes the inciting incident, central cast, and first irreversible commitment.",
+                "Act II escalates costs, reversals, and relationship pressure without repeating the premise.",
+                "Act III resolves the core conflict through one primary climax and a paid-for ending.",
+            ],
+            "cast": cast,
+            "character_agendas": agendas,
+            "canon_registry": canon_registry,
+            "conflict_ladder": [
+                "The protagonist discovers the central pressure.",
+                "The opposition turns progress into a personal or public cost.",
+                "The final choice resolves the ending promise at irreversible cost.",
+            ],
+            "world_rules": list(brief.get("world_rules", [])) or ["Progress must create a visible consequence."],
+            "core_system_rules": ["Major systems and factions change state only through on-page causes."],
+            "prose_guardrails": [
+                "Avoid abstract thesis-statement endings.",
+                "Do not let technical wins arrive without cost.",
+                "Vary chapter modes and include breathers after intense escalation.",
+            ],
+            "genre_contract": list(profile.genre_contract),
+            "style_profile": {
+                "narrative_voice": brief.get("tone") or "Clear close narration with concrete sensory pressure.",
+                "sentence_rhythm": "Vary sentence length and avoid repetitive summary cadence.",
+                "imagery_palette": list(brief.get("style_targets", [])) or ["concrete objects", "visible consequences"],
+                "dialogue_rules": list(brief.get("dialogue_targets", [])) or ["Use pressure and subtext over exposition."],
+                "character_voice_map": {
+                    member["name"]: "Distinct under pressure; avoid interchangeable dialogue."
+                    for member in cast
+                },
+                "avoid": list(brief.get("style_avoid", [])) or ["generic stakes language"],
+            },
+            "ending_promise": brief.get("ending_target") or f"{protagonist} must resolve the central conflict at a visible cost.",
+        }
+    )
+
+
+def _fallback_chapter_mode(chapter_number: int) -> str:
+    pattern = [
+        "systems_crisis",
+        "investigation",
+        "aftermath",
+        "interpersonal_confrontation",
+        "physical_escape",
+        "moral_negotiation",
+        "breather",
+        "reversal",
+    ]
+    return pattern[(chapter_number - 1) % len(pattern)]
+
+
+def _fallback_outcome_type(chapter_number: int, total_chapters: int) -> str:
+    if chapter_number == total_chapters:
+        return "reversal"
+    if chapter_number % 5 == 0:
+        return "reversal"
+    if chapter_number % 2 == 0:
+        return "setback"
+    return "compromise"
+
+
+def _fallback_act(chapter_number: int, total_chapters: int) -> str:
+    if chapter_number <= max(1, total_chapters // 4):
+        return "Act I"
+    if chapter_number < total_chapters:
+        return "Act II"
+    return "Act III"
+
+
+def _fallback_outline_entries(
+    project: Any,
+    story_bible: StoryBible,
+    start_chapter: int,
+    end_chapter: int,
+    total_chapters: int,
+) -> list[dict[str, Any]]:
+    protagonist = story_bible.cast[0].name if story_bible.cast else "The protagonist"
+    support = story_bible.cast[1].name if len(story_bible.cast) > 1 else "a trusted ally"
+    canon_name = story_bible.canon_registry[0].name if story_bible.canon_registry else "the central pressure"
+    entries: list[dict[str, Any]] = []
+    for chapter_number in range(start_chapter, end_chapter + 1):
+        mode = _fallback_chapter_mode(chapter_number)
+        entries.append(
+            {
+                "chapter_number": chapter_number,
+                "act": _fallback_act(chapter_number, total_chapters),
+                "title": f"Pressure Point {chapter_number}",
+                "objective": f"{protagonist} pursues step {chapter_number} toward the ending promise without repeating the inciting incident.",
+                "conflict_turn": f"{canon_name} forces a new cost in chapter {chapter_number}.",
+                "character_turn": f"{protagonist} changes tactics after {support} challenges the price of progress.",
+                "reveal": f"A concrete limit or hidden cost of {canon_name} becomes visible.",
+                "ending_state": f"The story state after chapter {chapter_number} cannot return to its prior balance.",
+                "outcome_type": _fallback_outcome_type(chapter_number, total_chapters),
+                "primary_obstacle": f"A specific obstacle blocks the next route to {story_bible.ending_promise}.",
+                "cost_if_success": f"Progress in chapter {chapter_number} costs access, trust, safety, or public standing.",
+                "side_character_friction": f"{support} resists because the plan endangers something they need.",
+                "independent_side_character_move": f"{support} takes an action that changes {protagonist}'s options.",
+                "concrete_ending_hook": {
+                    "trigger": f"A visible consequence of chapter {chapter_number} arrives.",
+                    "visible_object_or_actor": f"{canon_name}",
+                    "next_problem": f"The next chapter must answer the cost exposed by chapter {chapter_number}.",
+                },
+                "chapter_mode": mode,
+                "civilian_life_detail": f"Ordinary people adapt around the fallout from chapter {chapter_number}.",
+                "emotional_reveal": f"{protagonist} admits a private fear that complicates the next choice.",
+                "ideology_pressure": story_bible.theme,
+                "genre_specific_beats": [f"Escalate the selected genre contract through chapter {chapter_number}."],
+                "genre_state_change": f"The genre pressure advances one irreversible notch in chapter {chapter_number}.",
+            }
+        )
+    return entries
+
+
+def _validated_outline_or_fallback(
+    session: Session,
+    project: Any,
+    run: GenerationRun,
+    story_bible: StoryBible,
+    outline: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    try:
+        return parse_outline(json.dumps({"chapters": outline}), run.requested_chapters)
+    except Exception as exc:
+        record_event(
+            session,
+            run,
+            "outline_validation_fallback",
+            {
+                "message": "Combined outline failed full-book validation; generated a deterministic outline.",
+                "error": str(exc),
+            },
+        )
+        return parse_outline(
+            json.dumps(
+                {
+                    "chapters": _fallback_outline_entries(
+                        project,
+                        story_bible,
+                        1,
+                        run.requested_chapters,
+                        run.requested_chapters,
+                    )
+                }
+            ),
+            run.requested_chapters,
+        )
+
+
 def _generate_story_bible(session: Session, run: GenerationRun, settings: Settings, client: ProviderManager | OllamaClient) -> StoryBible:
     project = run.project
     provider_name, model_name = _resolve_stage_route(client, run, "story_bible")
@@ -528,14 +759,26 @@ def _generate_story_bible(session: Session, run: GenerationRun, settings: Settin
         {"message": "Generating story bible.", "provider_name": provider_name, "model_name": model_name},
     )
     session.commit()
-    story_bible = _generate_structured_output(
-        client,
-        provider_name,
-        model_name,
-        lambda: build_story_bible_messages(project, run),
-        parse_story_bible,
-        "story bible",
-    )
+    try:
+        story_bible = _generate_structured_output(
+            client,
+            provider_name,
+            model_name,
+            lambda: build_story_bible_messages(project, run),
+            parse_story_bible,
+            "story bible",
+        )
+    except Exception as exc:
+        story_bible = _fallback_story_bible(project, run)
+        record_event(
+            session,
+            run,
+            "story_bible_fallback",
+            {
+                "message": "Story bible model output was unusable after repair; generated a deterministic story bible.",
+                "error": str(exc),
+            },
+        )
     selected_profile = genre_profile((project.story_brief or {}).get("genre_profile"))
     story_bible = story_bible.model_copy(
         update={
@@ -558,6 +801,82 @@ def _generate_story_bible(session: Session, run: GenerationRun, settings: Settin
     return story_bible
 
 
+def _generate_outline_chunks(
+    session: Session,
+    run: GenerationRun,
+    story_bible: StoryBible,
+    client: ProviderManager | OllamaClient,
+    provider_name: str,
+    model_name: str,
+) -> list[dict[str, Any]]:
+    project = run.project
+    outline: list[dict[str, Any]] = []
+    for start_chapter in range(1, run.requested_chapters + 1, OUTLINE_CHUNK_SIZE):
+        end_chapter = min(run.requested_chapters, start_chapter + OUTLINE_CHUNK_SIZE - 1)
+        record_event(
+            session,
+            run,
+            "outline_chunk_started",
+            {
+                "message": f"Generating outline chapters {start_chapter}-{end_chapter}.",
+                "start_chapter": start_chapter,
+                "end_chapter": end_chapter,
+                "provider_name": provider_name,
+                "model_name": model_name,
+            },
+        )
+        session.commit()
+        try:
+            chunk = _generate_structured_output(
+                client,
+                provider_name,
+                model_name,
+                lambda start=start_chapter, end=end_chapter, prior=list(outline): build_outline_chunk_messages(
+                    project,
+                    run,
+                    story_bible,
+                    start_chapter=start,
+                    end_chapter=end,
+                    prior_outline=prior,
+                ),
+                lambda raw, start=start_chapter, end=end_chapter: parse_outline_chunk(raw, start, end),
+                f"structured outline chapters {start_chapter}-{end_chapter}",
+            )
+        except Exception as exc:
+            chunk = _fallback_outline_entries(
+                project,
+                story_bible,
+                start_chapter,
+                end_chapter,
+                run.requested_chapters,
+            )
+            record_event(
+                session,
+                run,
+                "outline_chunk_fallback",
+                {
+                    "message": f"Outline chunk {start_chapter}-{end_chapter} was unusable after repair; generated deterministic entries.",
+                    "error": str(exc),
+                    "start_chapter": start_chapter,
+                    "end_chapter": end_chapter,
+                },
+            )
+        outline.extend(chunk)
+        record_event(
+            session,
+            run,
+            "outline_chunk_completed",
+            {
+                "message": f"Accepted outline chapters {start_chapter}-{end_chapter}.",
+                "start_chapter": start_chapter,
+                "end_chapter": end_chapter,
+                "chapters": len(chunk),
+            },
+        )
+        session.commit()
+    return outline
+
+
 def _generate_outline(session: Session, run: GenerationRun, story_bible: StoryBible, client: ProviderManager | OllamaClient) -> None:
     project = run.project
     provider_name, model_name = _resolve_stage_route(client, run, "outline")
@@ -569,14 +888,30 @@ def _generate_outline(session: Session, run: GenerationRun, story_bible: StoryBi
         {"message": "Generating structured outline.", "provider_name": provider_name, "model_name": model_name},
     )
     session.commit()
-    run.outline = _generate_structured_output(
-        client,
-        provider_name,
-        model_name,
-        lambda: build_outline_messages(project, run, story_bible),
-        lambda raw: parse_outline(raw, run.requested_chapters),
-        "structured outline",
-    )
+    try:
+        if run.requested_chapters > OUTLINE_CHUNK_THRESHOLD:
+            outline = _generate_outline_chunks(session, run, story_bible, client, provider_name, model_name)
+        else:
+            outline = _generate_structured_output(
+                client,
+                provider_name,
+                model_name,
+                lambda: build_outline_messages(project, run, story_bible),
+                lambda raw: parse_outline(raw, run.requested_chapters),
+                "structured outline",
+            )
+        run.outline = _validated_outline_or_fallback(session, project, run, story_bible, outline)
+    except Exception as exc:
+        run.outline = _fallback_outline_entries(project, story_bible, 1, run.requested_chapters, run.requested_chapters)
+        record_event(
+            session,
+            run,
+            "outline_fallback",
+            {
+                "message": "Outline model output was unusable after repair; generated a deterministic outline.",
+                "error": str(exc),
+            },
+        )
     create_chapters_from_outline(session, run)
     record_event(session, run, "outline_completed", {"chapters": len(run.outline or [])})
     session.commit()

--- a/src/novel_generator/services/prompts.py
+++ b/src/novel_generator/services/prompts.py
@@ -349,6 +349,94 @@ def build_outline_messages(project: Project, run: GenerationRun, story_bible: St
     ]
 
 
+def build_outline_chunk_messages(
+    project: Project,
+    run: GenerationRun,
+    story_bible: StoryBible | dict[str, Any],
+    *,
+    start_chapter: int,
+    end_chapter: int,
+    prior_outline: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    bible = story_bible if isinstance(story_bible, dict) else story_bible.model_dump()
+    profile = _story_bible_genre_profile(bible)
+    chapter_mode_options = _chapter_mode_options()
+    chapter_count = end_chapter - start_chapter + 1
+    midpoint_start = max(2, math.ceil(run.requested_chapters * 0.4))
+    midpoint_end = max(midpoint_start, math.floor(run.requested_chapters * 0.7))
+    midpoint_rule = (
+        f"- this chunk intersects the midpoint window; include at least one outcome_type reversal between chapters {midpoint_start} and {midpoint_end}\n"
+        if start_chapter <= midpoint_end and end_chapter >= midpoint_start
+        else ""
+    )
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a meticulous fiction outliner. Return valid JSON only. "
+                "Generate only the requested contiguous chapter slice, not the whole book."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Create chapters {start_chapter} through {end_chapter} for a {run.requested_chapters}-chapter outline of '{project.title}'.\n"
+                f"Return exactly {chapter_count} chapters, numbered {start_chapter} through {end_chapter}; do not restart at chapter 1.\n"
+                f"{_story_brief_lines(project)}\n\n"
+                f"Story bible:\n{json.dumps(bible, indent=2)}\n\n"
+                f"Selected genre profile:\n{_genre_profile_block(profile)}\n\n"
+                f"Prior outline chapters already accepted:\n{json.dumps(prior_outline[-12:], indent=2)}\n\n"
+                "Return a JSON object in this shape:\n"
+                "{\n"
+                '  "chapters": [\n'
+                "    {\n"
+                f'      "chapter_number": {start_chapter},\n'
+                '      "act": "Act I|Act II|Act III",\n'
+                '      "title": "string",\n'
+                '      "objective": "string",\n'
+                '      "conflict_turn": "string",\n'
+                '      "character_turn": "string",\n'
+                '      "reveal": "string",\n'
+                '      "ending_state": "string",\n'
+                '      "outcome_type": "win|setback|reversal|compromise",\n'
+                '      "primary_obstacle": "string",\n'
+                '      "cost_if_success": "string",\n'
+                '      "side_character_friction": "string",\n'
+                '      "independent_side_character_move": "string",\n'
+                '      "concrete_ending_hook": {\n'
+                '        "trigger": "string",\n'
+                '        "visible_object_or_actor": "string",\n'
+                '        "next_problem": "string"\n'
+                "      },\n"
+                f'      "chapter_mode": "{chapter_mode_options}",\n'
+                '      "civilian_life_detail": "string",\n'
+                '      "emotional_reveal": "string",\n'
+                '      "ideology_pressure": "string",\n'
+                '      "genre_specific_beats": ["profile-specific beat 1", "profile-specific beat 2"],\n'
+                '      "genre_state_change": "string"\n'
+                "    }\n"
+                "  ]\n"
+                "}\n\n"
+                "Rules:\n"
+                f"- return exactly chapters {start_chapter} through {end_chapter}, no missing chapters and no extra chapters\n"
+                "- continue the prior outline instead of repeating its inciting incident, discovery, midpoint, or climax\n"
+                "- each chapter must change the external situation and at least one character state\n"
+                "- use setback or reversal often enough that the full book does not become a clean-win chain\n"
+                f"{midpoint_rule}"
+                "- every local block of 4 chapters should include at least 1 chapter_mode of breather or aftermath when possible\n"
+                "- do not repeat any chapter_mode used by either of the previous 2 accepted chapters\n"
+                f"- use only these chapter_mode values: {chapter_mode_options}\n"
+                "- side_character_friction must name who pushes back on the protagonist and why\n"
+                "- independent_side_character_move must name a side character action that changes the protagonist's options\n"
+                "- cost_if_success must describe the price of progress, not just the risk of failure\n"
+                "- concrete_ending_hook must end on a specific actor, object, interruption, arrival, discovery, or reversal\n"
+                "- civilian_life_detail, emotional_reveal, ideology_pressure, genre_specific_beats, and genre_state_change must be filled for every chapter\n"
+                "- preserve one clean climax and one primary ending in the final chapter only"
+            ),
+        },
+    ]
+
+
 def rolling_context(chapters: list[ChapterDraft], window: int) -> str:
     completed = [chapter for chapter in chapters if chapter.summary]
     recent = completed[-window:]
@@ -1050,6 +1138,51 @@ def _normalize_outline_payload(payload: Any) -> Any:
             return [payload[key] for key in sorted(payload.keys(), key=lambda item: int(str(item).strip()))]
 
     return payload
+
+
+def parse_outline_chunk(text: str, start_chapter: int, end_chapter: int) -> list[dict[str, Any]]:
+    payload = _normalize_outline_payload(extract_json_payload(text))
+    try:
+        outline = TypeAdapter(list[StructuredOutlineEntry]).validate_python(payload)
+    except ValidationError as exc:
+        raise ValueError(f"Outline chunk JSON was invalid: {exc}") from exc
+
+    expected_numbers = list(range(start_chapter, end_chapter + 1))
+    actual_numbers = [item.chapter_number for item in outline]
+    if actual_numbers != expected_numbers:
+        raise ValueError(
+            "Outline chunk returned chapter numbers "
+            + ", ".join(str(number) for number in actual_numbers)
+            + f", but expected {start_chapter} through {end_chapter}."
+        )
+
+    if any(not item.chapter_mode.strip() for item in outline):
+        raise ValueError("Outline chunk entries must include a chapter_mode for every chapter.")
+
+    invalid_modes = sorted({item.chapter_mode for item in outline if item.chapter_mode not in ALLOWED_CHAPTER_MODES})
+    if invalid_modes:
+        raise ValueError(
+            "Outline chunk entries use unsupported chapter_mode values: "
+            + ", ".join(invalid_modes)
+            + "."
+        )
+
+    for item in outline:
+        if item.chapter_mode.lower() in {"breather", "aftermath"}:
+            if not item.civilian_life_detail.strip():
+                raise ValueError(
+                    f"Breather or aftermath chapter {item.chapter_number} is missing civilian_life_detail."
+                )
+            if not item.emotional_reveal.strip():
+                raise ValueError(
+                    f"Breather or aftermath chapter {item.chapter_number} is missing emotional_reveal."
+                )
+            if not item.ideology_pressure.strip():
+                raise ValueError(
+                    f"Breather or aftermath chapter {item.chapter_number} is missing ideology_pressure."
+                )
+
+    return [item.model_dump() for item in outline]
 
 
 def parse_outline(text: str, requested_chapters: int) -> list[dict[str, Any]]:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -132,6 +132,64 @@ def _outline_json(chapters: int) -> str:
     return json.dumps(payload)
 
 
+def _valid_outline_entry(index: int, total_chapters: int) -> dict[str, object]:
+    chapter_modes = [
+        "systems_crisis",
+        "investigation",
+        "aftermath",
+        "interpersonal_confrontation",
+        "physical_escape",
+        "moral_negotiation",
+        "breather",
+        "reversal",
+    ]
+    outcome_type = "reversal" if index == total_chapters or index % 5 == 0 else ("setback" if index % 2 == 0 else "compromise")
+    return {
+        "chapter_number": index,
+        "act": "Act I" if index <= total_chapters // 4 else ("Act II" if index < total_chapters else "Act III"),
+        "title": f"Pressure Point {index}",
+        "objective": f"Iris pursues step {index} without repeating the inciting incident.",
+        "conflict_turn": f"The living map forces a new cost in chapter {index}.",
+        "character_turn": f"Iris changes tactics after Tarin challenges the price of progress in chapter {index}.",
+        "reveal": f"A hidden limit of the living map becomes visible in chapter {index}.",
+        "ending_state": f"Chapter {index} leaves the route altered in a way Iris cannot undo.",
+        "outcome_type": outcome_type,
+        "primary_obstacle": f"A civic barrier blocks route {index}.",
+        "cost_if_success": f"Progress in chapter {index} costs access, trust, or safety.",
+        "side_character_friction": f"Tarin resists because chapter {index} endangers frightened civilians.",
+        "independent_side_character_move": f"Tarin redirects the route token in chapter {index}.",
+        "concrete_ending_hook": {
+            "trigger": f"A visible consequence of chapter {index} arrives.",
+            "visible_object_or_actor": f"Visible actor {index}",
+            "next_problem": f"The next chapter must answer cost {index}.",
+        },
+        "chapter_mode": chapter_modes[(index - 1) % len(chapter_modes)],
+        "civilian_life_detail": f"Families adapt around the fallout from chapter {index}.",
+        "emotional_reveal": f"Iris admits a private fear that complicates choice {index}.",
+        "ideology_pressure": "Consent matters even when delay is dangerous.",
+        "genre_specific_beats": [f"The clue chain advances through chapter {index}."],
+        "genre_state_change": f"The living map pressure advances in chapter {index}.",
+    }
+
+
+def _valid_outline_chunk_json(start_chapter: int, end_chapter: int, total_chapters: int = 64) -> str:
+    return json.dumps(
+        {
+            "chapters": [
+                _valid_outline_entry(index, total_chapters)
+                for index in range(start_chapter, end_chapter + 1)
+            ]
+        }
+    )
+
+
+def _valid_outline_chunk_responses(total_chapters: int = 64) -> list[str]:
+    return [
+        _valid_outline_chunk_json(start_chapter, min(total_chapters, start_chapter + 7), total_chapters)
+        for start_chapter in range(1, total_chapters + 1, 8)
+    ]
+
+
 def _story_turn_payload(index: int) -> dict[str, object]:
     turns: dict[int, dict[str, object]] = {
         1: {
@@ -386,6 +444,88 @@ def test_process_run_safe_pauses_after_outline_when_requested(configured_environ
         assert refreshed.outline is not None
         assert len(refreshed.chapters) == 2
         assert len(refreshed.artifacts) == 0
+
+
+def test_large_run_generates_outline_in_chunks_and_pauses(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=64)
+        run = create_run(session, project, RunCreate(project_id=project.id, model_name="test-model"))
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient([_story_bible_json(), *_valid_outline_chunk_responses()]),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.AWAITING_APPROVAL
+        assert refreshed.current_step == "outline_review"
+        assert refreshed.outline is not None
+        assert len(refreshed.outline) == 64
+        assert [entry["chapter_number"] for entry in refreshed.outline] == list(range(1, 65))
+        assert len(refreshed.chapters) == 64
+        assert sum(event.event_type == "outline_chunk_completed" for event in refreshed.events) == 8
+
+
+def test_large_outline_chunk_fallback_prevents_short_outline_failure(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=64)
+        run = create_run(session, project, RunCreate(project_id=project.id, model_name="test-model"))
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient(
+                [
+                    _story_bible_json(),
+                    json.dumps({"chapters": []}),
+                    json.dumps({"chapters": []}),
+                    *_valid_outline_chunk_responses()[1:],
+                ]
+            ),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.AWAITING_APPROVAL
+        assert refreshed.outline is not None
+        assert len(refreshed.outline) == 64
+        assert [entry["chapter_number"] for entry in refreshed.outline] == list(range(1, 65))
+        assert any(event.event_type == "outline_chunk_fallback" for event in refreshed.events)
+
+
+def test_story_bible_fallback_prevents_shape_failure(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=2)
+        run = create_run(session, project, RunCreate(project_id=project.id, model_name="test-model"))
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient(["[]", "[]", _outline_json(2)]),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.AWAITING_APPROVAL
+        assert refreshed.story_bible["logline"] == project.premise
+        assert any(event.event_type == "story_bible_fallback" for event in refreshed.events)
 
 
 def test_process_run_merges_approved_project_canon_into_story_bible(configured_environment) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -8,6 +8,7 @@ from novel_generator.services.prompts import (
     build_chapter_plan_messages,
     build_chapter_revision_messages,
     build_continuity_update_messages,
+    build_outline_chunk_messages,
     build_developmental_rewrite_messages,
     build_manuscript_qa_messages,
     build_story_bible_messages,
@@ -17,6 +18,7 @@ from novel_generator.services.prompts import (
     parse_developmental_rewrite_plan,
     parse_manuscript_qa_report,
     parse_outline,
+    parse_outline_chunk,
     parse_story_bible,
     rolling_context,
     sanitize_chapter_content,
@@ -797,6 +799,108 @@ def test_continuity_update_prompt_requests_system_state_transitions() -> None:
     assert '"system_state_transitions"' in prompt
     assert '"previous_state"' in prompt
     assert "previous_state matching the current ledger" in prompt
+
+
+def test_outline_chunk_prompt_and_parser_use_absolute_chapter_numbers() -> None:
+    project = Project(
+        title="The Glass Orchard",
+        premise="An archivist finds a living map under a failing city.",
+        desired_word_count=64000,
+        requested_chapters=64,
+        min_words_per_chapter=900,
+        max_words_per_chapter=1200,
+        preferred_model="test-model",
+        story_brief={},
+    )
+    run = GenerationRun(
+        project=project,
+        model_name="test-model",
+        target_word_count=64000,
+        requested_chapters=64,
+        min_words_per_chapter=900,
+        max_words_per_chapter=1200,
+    )
+    story_bible = {
+        "logline": "A map wakes.",
+        "theme": "Freedom costs more than obedience.",
+        "act_plan": ["Discovery", "Descent", "Choice"],
+        "cast": [{"name": "Iris", "role": "Archivist", "desire": "Find the map", "risk": "Becoming its tool"}],
+        "character_agendas": [],
+        "canon_registry": [],
+        "conflict_ladder": [],
+        "world_rules": [],
+        "core_system_rules": [],
+        "prose_guardrails": [],
+        "ending_promise": "Iris chooses whether to free the city.",
+    }
+
+    prompt = build_outline_chunk_messages(
+        project,
+        run,
+        story_bible,
+        start_chapter=9,
+        end_chapter=10,
+        prior_outline=[{"chapter_number": 8, "title": "Prior"}],
+    )[-1]["content"]
+    parsed = parse_outline_chunk(
+        """
+        {
+          "chapters": [
+            {
+              "chapter_number": 9,
+              "act": "Act II",
+              "title": "Ninth Pressure",
+              "objective": "Iris follows the map into a flooded civic exchange.",
+              "conflict_turn": "The map opens a route only after Tarin refuses her shortcut.",
+              "character_turn": "Iris accepts that speed without consent repeats the city's old harm.",
+              "reveal": "The exchange still stores living witness names.",
+              "ending_state": "Iris carries the witness names and cannot pretend the route is empty.",
+              "outcome_type": "setback",
+              "primary_obstacle": "The exchange rejects unauthorized memories.",
+              "cost_if_success": "Progress exposes civilians who wanted to stay hidden.",
+              "side_character_friction": "Tarin refuses to trade names for speed.",
+              "independent_side_character_move": "Tarin seals the shortcut until Iris agrees to warn the witnesses.",
+              "concrete_ending_hook": {"trigger": "A hidden witness lantern ignites.", "visible_object_or_actor": "the witness lantern", "next_problem": "The lantern names Iris aloud."},
+              "chapter_mode": "investigation",
+              "civilian_life_detail": "Families dry laundry on broken exchange rails.",
+              "emotional_reveal": "Iris admits she has started thinking like the map.",
+              "ideology_pressure": "Consent matters even when delay is dangerous.",
+              "genre_specific_beats": ["The clue chain reveals a hidden witness system."],
+              "genre_state_change": "The witness clue becomes active."
+            },
+            {
+              "chapter_number": 10,
+              "act": "Act II",
+              "title": "Tenth Pressure",
+              "objective": "Iris escorts the witnesses out before the map reroutes them.",
+              "conflict_turn": "The route collapses after one witness lies about their name.",
+              "character_turn": "Tarin chooses to protect the liar instead of the fastest exit.",
+              "reveal": "The map cannot read chosen names.",
+              "ending_state": "The party learns a way to blind the map at personal cost.",
+              "outcome_type": "reversal",
+              "primary_obstacle": "The map punishes false identities.",
+              "cost_if_success": "The witnesses lose their safest route.",
+              "side_character_friction": "Tarin argues that survival without privacy is still captivity.",
+              "independent_side_character_move": "Tarin gives the witness his own route token.",
+              "concrete_ending_hook": {"trigger": "The token turns black.", "visible_object_or_actor": "Tarin's route token", "next_problem": "Tarin is locked out of the safe stair."},
+              "chapter_mode": "aftermath",
+              "civilian_life_detail": "Witness children count ration beads beside the drained fountain.",
+              "emotional_reveal": "Tarin admits the map once sold his family's route.",
+              "ideology_pressure": "Privacy becomes the price of safety.",
+              "genre_specific_beats": ["The system rule creates a new tactical cost."],
+              "genre_state_change": "The map's identity rule is exposed."
+            }
+          ]
+        }
+        """,
+        9,
+        10,
+    )
+
+    assert "numbered 9 through 10" in prompt
+    assert "do not restart at chapter 1" in prompt
+    assert '"chapter_number": 9' in prompt
+    assert [item["chapter_number"] for item in parsed] == [9, 10]
 
 
 def test_developmental_rewrite_parser_accepts_wrapped_plan() -> None:


### PR DESCRIPTION
## Summary
- Split outlines above 32 chapters into validated 8-chapter model calls so 64-chapter runs no longer depend on one giant JSON response.
- Added chunk-level validation, full-book validation, and deterministic fallbacks for unusable story bible, chunk, or combined outline output.
- Added regression coverage for clean 64-chapter outline generation, malformed/short outline chunk fallback, malformed story-bible fallback, and absolute chapter numbering in chunk prompts.

## Root Cause
Recent 64-chapter runs failed before drafting because the outline stage asked the model for the entire book in a single structured JSON response. The model returned truncated outlines, wrong chapter counts, malformed JSON, or occasionally a wrong top-level story-bible shape. The pipeline treated those as terminal failures.

## Validation
- `docker compose exec -T web python -m pytest tests/test_prompts.py tests/test_pipeline.py`
- `docker compose exec -T web python -m pytest`
- `docker compose up --build -d web worker`
- Confirmed deployed containers are healthy and runtime reports large-outline chunk settings `32 8`.