### PR TITLE
[codex] Add run confidence center

### DIFF
--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -329,6 +329,120 @@ def _stage_context(run: GenerationRun) -> tuple[dict[str, Any], dict[str, Any] |
     return current_stage, next_stage
 
 
+def _event_display_name(event_type: str) -> str:
+    return str(event_type or "update").replace("_", " ")
+
+
+def _event_summary(event: Any | None) -> dict[str, Any] | None:
+    if event is None:
+        return None
+    payload = event.payload or {}
+    summary = (
+        payload.get("message")
+        or payload.get("title")
+        or payload.get("chapter_number")
+        or _event_display_name(event.event_type)
+    )
+    return {
+        "sequence": event.sequence,
+        "event_type": event.event_type,
+        "label": _event_display_name(event.event_type),
+        "summary": str(summary),
+    }
+
+
+def _latest_event_summary(run: GenerationRun) -> dict[str, Any] | None:
+    events = _sorted_run_events(run)
+    return _event_summary(events[-1] if events else None)
+
+
+def _fallback_event_rows(run: GenerationRun) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for event in _sorted_run_events(run):
+        if "fallback" not in str(event.event_type):
+            continue
+        summary = _event_summary(event)
+        if summary:
+            rows.append(summary)
+    return rows[-4:]
+
+
+def _run_progress_context(run: GenerationRun) -> dict[str, Any]:
+    completed_chapters = _chapter_completion_count(run)
+    requested_chapters = max(1, int(run.requested_chapters or 1))
+    tracked_chapters = len(run.chapters)
+    chapter_percent = min(100, int(round((completed_chapters / requested_chapters) * 100)))
+    return {
+        "completed_chapters": completed_chapters,
+        "tracked_chapters": tracked_chapters,
+        "requested_chapters": run.requested_chapters,
+        "chapter_percent": chapter_percent,
+        "word_count": _run_word_count(run),
+        "word_percent": _word_progress_percent(run),
+        "artifact_count": len(run.artifacts),
+        "label": f"{completed_chapters}/{run.requested_chapters} chapters complete",
+    }
+
+
+def _run_health_context(run: GenerationRun) -> dict[str, Any]:
+    current_stage, next_stage = _stage_context(run)
+    latest_event = _latest_event_summary(run)
+    fallback_events = _fallback_event_rows(run)
+    progress = _run_progress_context(run)
+
+    if run.status == RunStatus.QUEUED:
+        tone = "warning"
+        title = "Queued and waiting for the worker"
+        body = "The run settings are saved. The next healthy sign is a story-bible event from the worker."
+    elif run.status == RunStatus.RUNNING:
+        tone = "success" if not fallback_events else "warning"
+        title = f"Running: {current_stage['label']}"
+        body = current_stage["description"]
+    elif run.status == RunStatus.AWAITING_APPROVAL:
+        tone = "warning"
+        title = "Outline review is waiting on you"
+        body = "Approve the outline to start drafting, or cancel and edit the project before the expensive chapter pass begins."
+    elif run.status == RunStatus.FAILED:
+        tone = "error"
+        failure_stage = RUN_STAGE_LOOKUP.get(str(run.current_step or ""), current_stage)
+        title = f"Stopped during {failure_stage['label']}"
+        body = run.error_message or (latest_event or {}).get("summary") or "Check the latest event before rerunning."
+    elif run.status == RunStatus.CANCELED:
+        tone = "error"
+        title = "Canceled before completion"
+        body = "This run is preserved for review. Rerun it, regenerate from a chapter, or delete it when you no longer need the history."
+    elif run.status == RunStatus.COMPLETED:
+        if progress["completed_chapters"] == run.requested_chapters:
+            tone = "success"
+            title = "Run completed with all requested chapters"
+            body = "Manuscript artifacts, QA feedback, and chapter checkpoints are ready for review."
+        else:
+            tone = "warning"
+            title = "Run completed with incomplete chapter coverage"
+            body = "Treat the output as partial and inspect the chapter list before exporting or rerunning."
+    else:
+        tone = "warning"
+        title = f"Run status: {run.status.value.replace('_', ' ')}"
+        body = current_stage["description"]
+
+    next_label = next_stage["label"] if next_stage else "No next stage"
+    if run.status == RunStatus.AWAITING_APPROVAL:
+        next_label = "Approve outline or cancel and edit"
+    elif run.status in TERMINAL_STATUSES:
+        next_label = "Review outputs and recovery actions"
+
+    return {
+        "tone": tone,
+        "title": title,
+        "body": body,
+        "current_stage": current_stage,
+        "next_label": next_label,
+        "latest_event": latest_event,
+        "fallback_events": fallback_events,
+        "progress": progress,
+    }
+
+
 def _safe_plan(chapter: Any | None) -> dict[str, Any]:
     if chapter is None or not chapter.plan:
         return {}
@@ -681,6 +795,21 @@ def _run_dashboard_context(run: GenerationRun) -> dict[str, Any]:
         "word_progress_percent": _word_progress_percent(run),
         "run_stage_data": RUN_STAGES,
         "event_count": len(run.events),
+        "run_health": _run_health_context(run),
+    }
+
+
+def _run_row_context(run: GenerationRun) -> dict[str, Any]:
+    current_stage, _ = _stage_context(run)
+    health = _run_health_context(run)
+    route = _latest_route_context(run)
+    return {
+        "run": run,
+        "stage_label": current_stage["label"],
+        "health": health,
+        "progress": health["progress"],
+        "latest_event": health["latest_event"],
+        "route": route,
     }
 
 
@@ -1427,6 +1556,7 @@ def _home_context(request: Request, db: Session, settings: Settings) -> dict[str
         "projects": projects,
         "recent_projects": projects[:3],
         "recent_runs": recent_runs,
+        "recent_run_rows": [_run_row_context(run) for run in recent_runs],
         "has_projects": bool(projects),
         "primary_action": primary_action,
         "ready_for_projects": ready_for_projects,
@@ -1528,6 +1658,7 @@ def _project_detail_context(
             provider_field="preferred_provider_name",
             model_field="preferred_model",
         ),
+        "project_run_rows": [_run_row_context(run) for run in run_stats["project_runs"]],
         "run_values": run_payload,
         "run_errors": run_errors or {},
         "run_task_route_rows": _task_route_rows(run_payload),

--- a/src/novel_generator/static/style.css
+++ b/src/novel_generator/static/style.css
@@ -1501,6 +1501,37 @@ code {
   gap: 0.75rem;
 }
 
+.run-health-card {
+  align-items: stretch;
+}
+
+.run-health-card h2 {
+  margin: 0;
+}
+
+.run-health-meta {
+  display: grid;
+  grid-template-columns: minmax(10rem, 0.8fr) minmax(14rem, 1.2fr);
+  gap: 0.75rem;
+  min-width: min(100%, 28rem);
+}
+
+.run-row-event {
+  margin-top: 0.1rem;
+}
+
+.run-row-action {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: 0.46rem 0.72rem;
+  border-radius: var(--radius);
+  border: 1px solid rgba(23, 99, 90, 0.2);
+  background: rgba(23, 99, 90, 0.08);
+  color: var(--accent-strong);
+  font-weight: 700;
+}
+
 .run-status-strip {
   display: grid;
   grid-template-columns: minmax(10rem, 1.25fr) repeat(5, minmax(7.2rem, 1fr));
@@ -1636,6 +1667,11 @@ code {
 
   .compact-details {
     margin-top: 0.5rem;
+  }
+
+  .run-health-meta {
+    grid-template-columns: 1fr;
+    min-width: 0;
   }
 }
 

--- a/src/novel_generator/static/ui.js
+++ b/src/novel_generator/static/ui.js
@@ -295,6 +295,12 @@ function setupRunDetail() {
   const stepNode = runDetail.querySelector("[data-run-step-label]");
   const chapterNode = runDetail.querySelector("[data-run-chapter-label]");
   const routeNode = runDetail.querySelector("[data-run-route-label]");
+  const runHealthNode = runDetail.querySelector("[data-run-health]");
+  const runHealthTitleNode = runDetail.querySelector("[data-run-health-title]");
+  const runHealthBodyNode = runDetail.querySelector("[data-run-health-body]");
+  const runHealthNextNode = runDetail.querySelector("[data-run-health-next]");
+  const runHealthLastNode = runDetail.querySelector("[data-run-health-last]");
+  const runHealthFallbackNode = runDetail.querySelector("[data-run-health-fallbacks]");
   const elapsedNode = runDetail.querySelector("[data-run-elapsed]");
   const completedChapterNode = runDetail.querySelector("[data-run-completed-chapters]");
   const wordProgressNode = runDetail.querySelector("[data-run-word-progress]");
@@ -574,6 +580,78 @@ function setupRunDetail() {
     };
   }
 
+  function eventLabel(eventType) {
+    return String(eventType || "update").replace(/_/g, " ");
+  }
+
+  function eventSummary(event) {
+    if (!event) {
+      return null;
+    }
+    const summary = event.payload?.message || event.payload?.title || event.payload?.chapter_number || eventLabel(event.event_type);
+    return {
+      sequence: event.sequence || "-",
+      label: eventLabel(event.event_type),
+      summary: String(summary),
+    };
+  }
+
+  function fallbackEvents(run) {
+    return sortedEvents(run)
+      .filter((event) => String(event.event_type || "").includes("fallback"))
+      .slice(-4)
+      .map(eventSummary)
+      .filter(Boolean);
+  }
+
+  function runHealth(run) {
+    const normalizedStage = normalizeStage(run.current_step || "", run.status || "");
+    const currentStage = stageFor(normalizedStage);
+    const nextStageIndex = stageOrder.indexOf(normalizedStage);
+    const nextStage = nextStageIndex >= 0 && nextStageIndex + 1 < stageOrder.length ? stageFor(stageOrder[nextStageIndex + 1]) : null;
+    const runEvents = sortedEvents(run);
+    const latestEvent = eventSummary(runEvents.length ? runEvents[runEvents.length - 1] : null);
+    const fallbacks = fallbackEvents(run);
+    const completedChapters = completedChapterCount(run);
+    const allChaptersComplete = completedChapters === Number(run.requested_chapters || 0);
+    let tone = "warning";
+    let title = `Run status: ${String(run.status || "queued").replace(/_/g, " ")}`;
+    let body = currentStage.description;
+    let nextLabel = nextStage ? nextStage.label : "No next stage";
+
+    if (run.status === "queued") {
+      title = "Queued and waiting for the worker";
+      body = "The run settings are saved. The next healthy sign is a story-bible event from the worker.";
+    } else if (run.status === "running") {
+      tone = fallbacks.length ? "warning" : "success";
+      title = `Running: ${currentStage.label}`;
+    } else if (run.status === "awaiting_approval") {
+      title = "Outline review is waiting on you";
+      body = "Approve the outline to start drafting, or cancel and edit the project before the expensive chapter pass begins.";
+      nextLabel = "Approve outline or cancel and edit";
+    } else if (run.status === "failed") {
+      tone = "error";
+      const failureStage = stageLookup[run.current_step || ""] || currentStage;
+      title = `Stopped during ${failureStage.label}`;
+      body = run.error_message || latestEvent?.summary || "Check the latest event before rerunning.";
+      nextLabel = "Review outputs and recovery actions";
+    } else if (run.status === "canceled") {
+      tone = "error";
+      title = "Canceled before completion";
+      body = "This run is preserved for review. Rerun it, regenerate from a chapter, or delete it when you no longer need the history.";
+      nextLabel = "Review outputs and recovery actions";
+    } else if (run.status === "completed") {
+      tone = allChaptersComplete ? "success" : "warning";
+      title = allChaptersComplete ? "Run completed with all requested chapters" : "Run completed with incomplete chapter coverage";
+      body = allChaptersComplete
+        ? "Manuscript artifacts, QA feedback, and chapter checkpoints are ready for review."
+        : "Treat the output as partial and inspect the chapter list before exporting or rerunning.";
+      nextLabel = "Review outputs and recovery actions";
+    }
+
+    return { tone, title, body, nextLabel, latestEvent, fallbacks };
+  }
+
   function buildQualitySignals(chapter) {
     if (!chapter?.qa_notes) {
       return [];
@@ -684,6 +762,31 @@ function setupRunDetail() {
       } else {
         setHidden(stageNextNode, true);
       }
+    }
+  }
+
+  function renderRunHealth(run) {
+    const health = runHealth(run);
+    if (runHealthNode) {
+      runHealthNode.className = `callout callout-${health.tone} run-health-card`;
+    }
+    if (runHealthTitleNode) {
+      runHealthTitleNode.textContent = health.title;
+    }
+    if (runHealthBodyNode) {
+      runHealthBodyNode.textContent = health.body;
+    }
+    if (runHealthNextNode) {
+      runHealthNextNode.textContent = health.nextLabel;
+    }
+    if (runHealthLastNode) {
+      runHealthLastNode.textContent = health.latestEvent?.summary || "No worker events yet.";
+    }
+    if (runHealthFallbackNode) {
+      setHidden(runHealthFallbackNode, !health.fallbacks.length);
+      runHealthFallbackNode.innerHTML = health.fallbacks
+        .map((event) => `<span class="meta-chip">${escapeHtml(event.label)} #${escapeHtml(event.sequence)}</span>`)
+        .join("");
     }
   }
 
@@ -949,6 +1052,7 @@ function setupRunDetail() {
     runDetail.dataset.runCompletedAt = run.completed_at || "";
 
     updateStatus(run.status || "queued", run.current_step || "queued", run.current_chapter || "");
+    renderRunHealth(run);
     renderStagePanel(run);
     renderContract(run);
     renderQuality(run);

--- a/src/novel_generator/templates/index.html
+++ b/src/novel_generator/templates/index.html
@@ -154,9 +154,10 @@
           <p>The newest background jobs across every project.</p>
         </div>
       </div>
-      {% if recent_runs %}
+      {% if recent_run_rows %}
         <div class="run-table">
-          {% for run in recent_runs %}
+          {% for row in recent_run_rows %}
+            {% set run = row.run %}
             <a class="run-row" href="/runs/{{ run.id }}">
               <div class="run-row-main">
                 <div class="run-row-top">
@@ -164,10 +165,13 @@
                   <span class="run-row-title">{{ run.project.title }}</span>
                 </div>
                 <div class="meta-chip-row">
-                  <span class="meta-chip long-value">{{ run.model_name }}</span>
-                  <span class="meta-chip">{{ run.current_step }}</span>
-                  <span class="meta-chip">{{ run.requested_chapters }} chapters</span>
+                  <span class="meta-chip long-value">{{ row.route.provider_name }} / {{ row.route.model_name }}</span>
+                  <span class="meta-chip">{{ row.stage_label }}</span>
+                  <span class="meta-chip">{{ row.progress.label }}</span>
                 </div>
+                <p class="field-note run-row-event">
+                  Latest: {{ row.latest_event.summary if row.latest_event else "No worker events yet." }}
+                </p>
               </div>
               <div class="run-row-meta">
                 <div class="meta-cluster">
@@ -176,8 +180,9 @@
                 </div>
                 <div class="meta-cluster">
                   <span class="run-meta-label">Progress</span>
-                  <span class="detail-value">{{ run.chapters|length }} tracked / {{ run.requested_chapters }} planned</span>
+                  <span class="detail-value">{{ row.progress.word_percent }}% words / {{ row.progress.artifact_count }} artifacts</span>
                 </div>
+                <span class="run-row-action">Open run</span>
               </div>
             </a>
           {% endfor %}

--- a/src/novel_generator/templates/project_detail.html
+++ b/src/novel_generator/templates/project_detail.html
@@ -627,7 +627,8 @@
   </div>
   {% if project_runs %}
     <div class="run-table">
-      {% for run in project_runs %}
+      {% for row in project_run_rows %}
+        {% set run = row.run %}
         <article class="run-row">
           <a class="run-row-link" href="/runs/{{ run.id }}">
             <div class="run-row-main">
@@ -636,11 +637,14 @@
                 <span class="run-row-title long-value">{{ run.model_name }}</span>
               </div>
               <div class="meta-chip-row">
-                <span class="meta-chip">{{ run.provider_name }}</span>
-                <span class="meta-chip">{{ run.requested_chapters }} chapters requested</span>
-                <span class="meta-chip">{{ run.current_step.replace("_", " ") }}</span>
+                <span class="meta-chip long-value">{{ row.route.provider_name }} / {{ row.route.model_name }}</span>
+                <span class="meta-chip">{{ row.progress.label }}</span>
+                <span class="meta-chip">{{ row.stage_label }}</span>
                 <span class="meta-chip">v{{ run.pipeline_version or 1 }}</span>
               </div>
+              <p class="field-note run-row-event">
+                Latest: {{ row.latest_event.summary if row.latest_event else "No worker events yet." }}
+              </p>
             </div>
             <div class="run-row-meta">
               <div class="meta-cluster">
@@ -648,8 +652,12 @@
                 <span class="detail-value">{{ run.created_at.strftime('%Y-%m-%d %H:%M') }}</span>
               </div>
               <div class="meta-cluster">
+                <span class="run-meta-label">Words</span>
+                <span class="detail-value">{{ row.progress.word_count }} / {{ run.target_word_count }}</span>
+              </div>
+              <div class="meta-cluster">
                 <span class="run-meta-label">Artifacts</span>
-                <span class="detail-value">{{ run.artifacts|length }}</span>
+                <span class="detail-value">{{ row.progress.artifact_count }}</span>
               </div>
             </div>
           </a>

--- a/src/novel_generator/templates/run_detail.html
+++ b/src/novel_generator/templates/run_detail.html
@@ -79,6 +79,31 @@
       </div>
     </div>
 
+    <section class="callout callout-{{ run_health.tone }} run-health-card" data-run-health>
+      <div class="callout-copy">
+        <p class="eyebrow">Run confidence</p>
+        <h2 data-run-health-title>{{ run_health.title }}</h2>
+        <p data-run-health-body>{{ run_health.body }}</p>
+      </div>
+      <div class="run-health-meta">
+        <div class="detail-item">
+          <span class="detail-label">Next milestone</span>
+          <strong data-run-health-next>{{ run_health.next_label }}</strong>
+        </div>
+        <div class="detail-item">
+          <span class="detail-label">Latest event</span>
+          <span class="detail-value" data-run-health-last>
+            {{ run_health.latest_event.summary if run_health.latest_event else "No worker events yet." }}
+          </span>
+        </div>
+        <div class="meta-chip-row{% if not run_health.fallback_events %} is-hidden{% endif %}" data-run-health-fallbacks>
+          {% for event in run_health.fallback_events %}
+            <span class="meta-chip">{{ event.label }} #{{ event.sequence }}</span>
+          {% endfor %}
+        </div>
+      </div>
+    </section>
+
     <details class="compact-details run-meta-details">
       <summary>Run details and route</summary>
       <div class="run-meta-grid">

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -5,7 +5,7 @@ import json
 
 from novel_generator.dependencies import get_session_factory
 from novel_generator.models import Artifact, ChapterStatus, RunStatus
-from novel_generator.repositories import create_chapters_from_outline, create_project, create_run, get_project, get_run
+from novel_generator.repositories import create_chapters_from_outline, create_project, create_run, get_project, get_run, record_event
 from novel_generator.schemas import ProjectCreate, ProviderCapabilities, RunCreate
 from novel_generator.services.ollama import OllamaClient
 from novel_generator.settings import get_settings
@@ -204,6 +204,8 @@ def test_home_connected_state_with_existing_projects_and_runs(client, monkeypatc
     assert response.status_code == 200
     assert "Recent projects" in response.text
     assert "Recent runs" in response.text
+    assert "Latest: No worker events yet." in response.text
+    assert "Open run" in response.text
     assert "Get ready in four steps" not in response.text
 
 
@@ -372,9 +374,60 @@ def test_run_detail_renders_stepper_and_event_log_hooks(client, monkeypatch) -> 
     assert 'data-run-stages-json' in response.text
     assert 'data-run-elapsed' in response.text
     assert "What The Worker Is Doing" in response.text
+    assert "Run confidence" in response.text
+    assert "Running: Draft chapter" in response.text
+    assert "Next milestone" in response.text
     assert "Current Chapter Contract" in response.text
     assert "Quality Signals" in response.text
     assert "Continuity Highlights" in response.text
+
+
+def test_run_detail_surfaces_fallback_recovery_guidance(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
+    _, run_id = seed_project_and_run()
+
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        run = get_run(session, run_id)
+        assert run is not None
+        run.status = RunStatus.RUNNING
+        run.current_step = "outline"
+        record_event(
+            session,
+            run,
+            "outline_chunk_fallback",
+            {"message": "Outline chunk 1-8 was unusable after repair; generated deterministic entries."},
+        )
+        session.commit()
+
+    response = client.get(f"/runs/{run_id}")
+
+    assert response.status_code == 200
+    assert "Run confidence" in response.text
+    assert "Running: Outline" in response.text
+    assert "Outline chunk 1-8 was unusable after repair" in response.text
+    assert "outline chunk fallback" in response.text
+
+
+def test_failed_run_detail_surfaces_recovery_guidance(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
+    _, run_id = seed_project_and_run()
+
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        run = get_run(session, run_id)
+        assert run is not None
+        run.status = RunStatus.FAILED
+        run.current_step = "outline"
+        run.error_message = "Outline returned 29 chapters, but 64 were required."
+        session.commit()
+
+    response = client.get(f"/runs/{run_id}")
+
+    assert response.status_code == 200
+    assert "Stopped during Outline" in response.text
+    assert "Outline returned 29 chapters, but 64 were required." in response.text
+    assert "Review outputs and recovery actions" in response.text
 
 
 def test_run_detail_renders_outline_approval_controls(client, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- adds run health context helpers for stage, provider route, progress, latest event, fallback events, and recovery guidance
- surfaces a run confidence panel on run detail with live SSE refresh hooks
- makes recent run rows on the dashboard and project page more actionable with stage, event, progress, artifact, and open-run affordances

## Validation
- `python -m pytest tests/test_ui_routes.py`
- `python -m pytest`

Note: local verification used a disposable CPython 3.12 runtime under the workspace because the host had no usable system Python and Docker was unavailable.