### PR TITLE
[codex] Add post-run review recovery

### DIFF
--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -1653,6 +1653,155 @@ def _run_comparison_card(run: GenerationRun) -> dict[str, Any]:
     }
 
 
+def _review_chip(label: str, tone: str = "neutral") -> dict[str, str]:
+    return {"label": label, "tone": tone}
+
+
+def _chapter_status_chips(chapter: Any) -> list[dict[str, str]]:
+    chips: list[dict[str, str]] = []
+    if chapter.word_count:
+        chips.append(_review_chip(f"{chapter.word_count} words", "neutral"))
+    if chapter.summary:
+        chips.append(_review_chip("Summary saved", "success"))
+    if chapter.continuity_update:
+        chips.append(_review_chip("Continuity updated", "success"))
+    if chapter.qa_notes:
+        chips.append(_review_chip("QA stored", "success"))
+    if chapter.content:
+        chips.append(_review_chip("Preview ready", "success"))
+    if chapter.error_message:
+        chips.append(_review_chip("Chapter error", "risk"))
+    return chips
+
+
+def _chapter_risk_chips(chapter: Any) -> list[dict[str, str]]:
+    notes = chapter.qa_notes or {}
+    if not notes:
+        return []
+    chips: list[dict[str, str]] = []
+    blocking_count = len(notes.get("blocking_issues", []) or [])
+    warning_count = len(notes.get("warnings", []) or []) + len(notes.get("soft_warnings", []) or [])
+    if notes.get("revision_required"):
+        chips.append(_review_chip("Revision required", "risk"))
+    if blocking_count:
+        chips.append(_review_chip(f"{blocking_count} blocking", "risk"))
+    if warning_count:
+        chips.append(_review_chip(f"{warning_count} warnings", "warning"))
+    if int(notes.get("ending_concreteness_score", 10) or 10) <= 5:
+        chips.append(_review_chip("Weak ending", "risk"))
+    if int(notes.get("scene_turn_resolution_score", 10) or 10) <= 5:
+        chips.append(_review_chip("Scene turn risk", "warning"))
+    if int(notes.get("repetition_risk_score", 0) or 0) >= 7:
+        chips.append(_review_chip("Repetition risk", "warning"))
+    if int(notes.get("technical_escalation_fatigue_score", 0) or 0) >= 7:
+        chips.append(_review_chip("Technical fatigue", "warning"))
+    if not chips:
+        chips.append(_review_chip("QA steady", "success"))
+    return chips
+
+
+def _chapter_continuity_chips(chapter: Any) -> list[dict[str, str]]:
+    update = chapter.continuity_update or {}
+    chips: list[dict[str, str]] = []
+    if update.get("chapter_outcome"):
+        chips.append(_review_chip("Outcome logged", "success"))
+    if update.get("open_threads"):
+        chips.append(_review_chip(f"{len(update.get('open_threads') or [])} open threads", "warning"))
+    if update.get("new_entities_introduced"):
+        chips.append(_review_chip(f"{len(update.get('new_entities_introduced') or [])} new entities", "neutral"))
+    if update.get("entity_state_changes"):
+        chips.append(_review_chip("Entity changes", "neutral"))
+    if update.get("trust_fractures"):
+        chips.append(_review_chip("Trust fracture", "warning"))
+    return chips
+
+
+def _chapter_review_cards(run: GenerationRun) -> list[dict[str, Any]]:
+    return [
+        {
+            "chapter": chapter,
+            "status_chips": _chapter_status_chips(chapter),
+            "risk_chips": _chapter_risk_chips(chapter),
+            "continuity_chips": _chapter_continuity_chips(chapter),
+        }
+        for chapter in _sorted_run_chapters(run)
+    ]
+
+
+def _run_editorial_next_step_context(run: GenerationRun, chapter_cards: list[dict[str, Any]]) -> dict[str, Any]:
+    show = run.status in TERMINAL_STATUSES
+    comparison_card = _run_comparison_card(run)
+    qa_artifact = comparison_card["qa_artifact"]
+    completed_runs = [candidate for candidate in _sort_runs(run.project) if candidate.status == RunStatus.COMPLETED]
+    top_risks = list(comparison_card["top_risks"])
+    if not top_risks:
+        top_risks = [
+            str(item)
+            for note in _run_qa_notes(run)
+            for item in [
+                *(note.get("blocking_issues", []) or []),
+                *(note.get("warnings", []) or []),
+                *(note.get("soft_warnings", []) or []),
+            ]
+        ][:3]
+
+    suggestions: list[dict[str, Any]] = []
+    for card in chapter_cards:
+        chapter = card["chapter"]
+        risk_labels = [chip["label"] for chip in card["risk_chips"] if chip["tone"] in {"risk", "warning"}]
+        if risk_labels:
+            suggestions.append(
+                {
+                    "chapter_number": chapter.chapter_number,
+                    "title": chapter.title,
+                    "reason": ", ".join(risk_labels[:2]),
+                }
+            )
+        if len(suggestions) >= 3:
+            break
+
+    if run.status == RunStatus.FAILED and not suggestions:
+        failed_chapter = next((card["chapter"] for card in chapter_cards if card["chapter"].status == ChapterStatus.FAILED), None)
+        chapter_number = (
+            failed_chapter.chapter_number
+            if failed_chapter
+            else run.current_chapter
+            or min(run.requested_chapters, _chapter_completion_count(run) + 1)
+        )
+        suggestions.append(
+            {
+                "chapter_number": chapter_number,
+                "title": f"Chapter {chapter_number}",
+                "reason": "Failure stopped the run before a clean handoff.",
+            }
+        )
+
+    if run.status == RunStatus.COMPLETED:
+        title = "Editorial next step"
+        body = "Use QA, chapter risks, comparison, and export options to decide whether this draft is ready or needs a targeted rerun."
+    elif run.status == RunStatus.FAILED:
+        title = "Recovery next step"
+        body = run.error_message or "The run stopped before completion. Start with the failure stage, then rerun or regenerate from the safest chapter boundary."
+    elif run.status == RunStatus.CANCELED:
+        title = "Recovery next step"
+        body = "This run was canceled before completion. Review the preserved outline, events, and completed chapters before trying again."
+    else:
+        title = "Next step"
+        body = ""
+
+    return {
+        "show": show,
+        "title": title,
+        "body": body,
+        "qa_artifact": qa_artifact,
+        "top_risks": top_risks[:3],
+        "regenerate_suggestions": suggestions[:3],
+        "compare_available": run.status == RunStatus.COMPLETED and len(completed_runs) >= 2,
+        "comparison_run_count": len(completed_runs),
+        "publication_available": run.status == RunStatus.COMPLETED,
+    }
+
+
 def _project_comparison_context(project: Project) -> dict[str, Any]:
     completed_runs = [
         run
@@ -2623,6 +2772,7 @@ def run_detail(
     completed_chapter_count = _chapter_completion_count(run)
     run_profile = genre_profile((run.story_bible or {}).get("genre_profile") or (run.project.story_brief or {}).get("genre_profile"))
     outline_review = _outline_review_context(run)
+    chapter_review_cards = _chapter_review_cards(run)
     return _render(
         request,
         "run_detail.html",
@@ -2639,6 +2789,8 @@ def run_detail(
             "awaiting_outline_approval": run.status == RunStatus.AWAITING_APPROVAL,
             "outline_entries": outline_review["entries"],
             "outline_review": outline_review,
+            "chapter_review_cards": chapter_review_cards,
+            "editorial_next_step": _run_editorial_next_step_context(run, chapter_review_cards),
             "story_bible": run.story_bible or {},
             "continuity_ledger": run.continuity_ledger or {},
             **_artifact_context(run),

--- a/src/novel_generator/static/style.css
+++ b/src/novel_generator/static/style.css
@@ -76,7 +76,8 @@ button:focus-visible,
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible,
-.model-chip:focus-visible {
+.model-chip:focus-visible,
+summary:focus-visible {
   outline: none;
   box-shadow: var(--focus);
 }
@@ -159,8 +160,10 @@ button {
   background: var(--accent);
   color: #fff;
   font-weight: 600;
+  line-height: 1.2;
   cursor: pointer;
   text-align: center;
+  white-space: normal;
   max-width: 100%;
 }
 
@@ -594,6 +597,9 @@ dd {
 .outline-filter-bar {
   display: grid;
   gap: 0.75rem;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .outline-summary-strip {
@@ -1258,6 +1264,33 @@ dd {
   background: rgba(23, 106, 90, 0.08);
 }
 
+.editorial-next-panel {
+  border-color: rgba(23, 106, 90, 0.2);
+}
+
+.editorial-next-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(18rem, 1.1fr) minmax(0, 0.85fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+.regenerate-suggestion-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.regenerate-suggestion {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem;
+  border: 1px solid rgba(217, 207, 192, 0.95);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.58);
+}
+
 .artifact-kind {
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -1294,18 +1327,80 @@ dd {
   gap: 0.55rem;
 }
 
+.chapter-scan-grid {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.75rem;
+  border: 1px solid rgba(217, 207, 192, 0.85);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.48);
+}
+
+.chapter-scan-row {
+  display: grid;
+  grid-template-columns: 5.5rem minmax(0, 1fr);
+  gap: 0.65rem;
+  align-items: start;
+}
+
+.review-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.85rem;
+  padding: 0.28rem 0.62rem;
+  border-radius: 999px;
+  border: 1px solid rgba(212, 221, 215, 0.95);
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--ink);
+  font-size: 0.86rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.review-chip-success {
+  border-color: rgba(23, 101, 59, 0.22);
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.review-chip-warning {
+  border-color: rgba(141, 104, 24, 0.24);
+  background: var(--warning-soft);
+  color: var(--warning);
+}
+
+.review-chip-risk {
+  border-color: rgba(166, 66, 51, 0.24);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
 .chapter-preview-shell {
   display: grid;
   gap: 0.65rem;
 }
 
 .chapter-preview-shell summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.65rem 0.75rem;
+  border-radius: var(--radius);
+  border: 1px solid rgba(217, 207, 192, 0.85);
+  background: rgba(255, 255, 255, 0.48);
   cursor: pointer;
   font-weight: 700;
 }
 
 .chapter-preview-shell summary:hover {
   color: var(--accent-strong);
+}
+
+.summary-meta {
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 600;
 }
 
 .chapter-preview {
@@ -1789,6 +1884,15 @@ code {
 
   .outline-filter-actions {
     align-items: stretch;
+  }
+
+  .editorial-next-grid,
+  .chapter-scan-row {
+    grid-template-columns: 1fr;
+  }
+
+  .regenerate-suggestion {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/src/novel_generator/static/ui.js
+++ b/src/novel_generator/static/ui.js
@@ -3,6 +3,7 @@ document.addEventListener("DOMContentLoaded", () => {
   setupModelPickers(document);
   setupRunModeNotes(document);
   setupOutlineReview(document);
+  setupReviewSections(document);
   setupProviderConsole();
   setupRunDetail();
 });
@@ -202,6 +203,30 @@ function setupOutlineReview(root) {
       syncFilters();
     });
     syncFilters();
+  });
+}
+
+function setupReviewSections(root) {
+  const sections = Array.from(root.querySelectorAll("[data-review-section]"));
+  sections.forEach((section) => {
+    if (section.dataset.reviewBound === "true") {
+      return;
+    }
+    section.dataset.reviewBound = "true";
+    section.addEventListener("toggle", () => {
+      if (!section.open) {
+        return;
+      }
+      const chapter = section.closest(".chapter-card");
+      if (!chapter) {
+        return;
+      }
+      Array.from(chapter.querySelectorAll("[data-review-section]")).forEach((peer) => {
+        if (peer !== section) {
+          peer.open = false;
+        }
+      });
+    });
   });
 }
 

--- a/src/novel_generator/templates/run_detail.html
+++ b/src/novel_generator/templates/run_detail.html
@@ -479,6 +479,74 @@
   </details>
 </section>
 
+{% if editorial_next_step.show %}
+  <section class="panel editorial-next-panel">
+    <div class="section-header">
+      <div class="section-header-copy">
+        <p class="eyebrow">Post-run review</p>
+        <h2>{{ editorial_next_step.title }}</h2>
+        <p>{{ editorial_next_step.body }}</p>
+      </div>
+      <div class="hero-actions">
+        {% if editorial_next_step.qa_artifact %}
+          <a class="button secondary" href="/api/artifacts/{{ editorial_next_step.qa_artifact.id }}/download">Download QA report</a>
+        {% endif %}
+        {% if editorial_next_step.compare_available %}
+          <a class="button secondary" href="/projects/{{ project.id }}/runs/compare">Compare completed drafts</a>
+        {% endif %}
+        {% if editorial_next_step.publication_available %}
+          <a class="button secondary" href="#publication-export">Publication export</a>
+        {% endif %}
+        <form method="post" action="/runs/{{ run.id }}/rerun">
+          <button type="submit">Run again</button>
+        </form>
+      </div>
+    </div>
+    <div class="editorial-next-grid">
+      <div class="detail-item">
+        <span class="detail-label">Top risks</span>
+        <ul class="bullet-list">
+          {% for risk in editorial_next_step.top_risks %}
+            <li>{{ risk }}</li>
+          {% else %}
+            <li>No elevated QA risks are recorded for this run.</li>
+          {% endfor %}
+        </ul>
+      </div>
+      <div class="detail-item">
+        <span class="detail-label">Regenerate suggestions</span>
+        {% if editorial_next_step.regenerate_suggestions %}
+          <div class="regenerate-suggestion-list">
+            {% for suggestion in editorial_next_step.regenerate_suggestions %}
+              <form method="post" action="/runs/{{ run.id }}/chapters/{{ suggestion.chapter_number }}/regenerate" class="regenerate-suggestion">
+                <div>
+                  <strong>Chapter {{ suggestion.chapter_number }}</strong>
+                  <p class="field-note">{{ suggestion.reason }}</p>
+                </div>
+                <button class="secondary" type="submit">Regenerate</button>
+              </form>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="empty-state">No targeted regeneration point stands out from chapter QA.</p>
+        {% endif %}
+      </div>
+      <div class="detail-item">
+        <span class="detail-label">Outputs</span>
+        <div class="meta-chip-row">
+          <span class="meta-chip">{{ run.artifacts|length }} artifacts</span>
+          <span class="meta-chip">{{ completed_chapter_count }}/{{ run.requested_chapters }} chapters complete</span>
+          {% if editorial_next_step.comparison_run_count > 1 %}
+            <span class="meta-chip">{{ editorial_next_step.comparison_run_count }} completed drafts</span>
+          {% else %}
+            <span class="meta-chip">Comparison after another completed draft</span>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  </section>
+{% endif %}
+
 {% if run.task_routing %}
   <section class="panel">
     <div class="section-header">
@@ -994,7 +1062,7 @@
     {% endif %}
   </article>
 
-  <article class="panel">
+  <article class="panel" id="publication-export">
     <div class="section-header">
       <div class="section-header-copy">
         <h2>Export For Publication</h2>
@@ -1035,9 +1103,10 @@
     </div>
     <p>{{ run.chapters|length }} tracked</p>
   </div>
-  {% if run.chapters %}
+  {% if chapter_review_cards %}
     <div class="chapter-list">
-      {% for chapter in run.chapters %}
+      {% for card in chapter_review_cards %}
+        {% set chapter = card.chapter %}
         <article class="chapter-card{% if run.current_chapter == chapter.chapter_number %} active-chapter{% endif %}">
           <div class="chapter-topline">
             <div class="chapter-heading">
@@ -1047,22 +1116,37 @@
             <span class="badge status-{{ chapter.status.value }}">{{ chapter.status.value }}</span>
           </div>
           <div class="chapter-body">
-            <div class="chapter-meta-row">
-              {% if chapter.word_count %}
-                <span class="meta-chip">{{ chapter.word_count }} words</span>
-              {% endif %}
-              {% if chapter.summary %}
-                <span class="meta-chip">Summary saved</span>
-              {% endif %}
-              {% if chapter.continuity_update %}
-                <span class="meta-chip">Continuity updated</span>
-              {% endif %}
-              {% if chapter.qa_notes %}
-                <span class="meta-chip">Critique stored</span>
-              {% endif %}
-              {% if chapter.content %}
-                <span class="meta-chip">Preview ready</span>
-              {% endif %}
+            <div class="chapter-scan-grid">
+              <div class="chapter-scan-row">
+                <span class="detail-label">Status</span>
+                <div class="meta-chip-row">
+                  {% for chip in card.status_chips %}
+                    <span class="review-chip review-chip-{{ chip.tone }}">{{ chip.label }}</span>
+                  {% else %}
+                    <span class="review-chip">Awaiting output</span>
+                  {% endfor %}
+                </div>
+              </div>
+              <div class="chapter-scan-row">
+                <span class="detail-label">QA risk</span>
+                <div class="meta-chip-row">
+                  {% for chip in card.risk_chips %}
+                    <span class="review-chip review-chip-{{ chip.tone }}">{{ chip.label }}</span>
+                  {% else %}
+                    <span class="review-chip">No QA yet</span>
+                  {% endfor %}
+                </div>
+              </div>
+              <div class="chapter-scan-row">
+                <span class="detail-label">Continuity</span>
+                <div class="meta-chip-row">
+                  {% for chip in card.continuity_chips %}
+                    <span class="review-chip review-chip-{{ chip.tone }}">{{ chip.label }}</span>
+                  {% else %}
+                    <span class="review-chip">No continuity update</span>
+                  {% endfor %}
+                </div>
+              </div>
             </div>
             <p class="muted chapter-copy">{{ chapter.outline_summary }}</p>
             {% if chapter.summary %}
@@ -1073,8 +1157,11 @@
             {% endif %}
 
             {% if chapter.qa_notes %}
-              <details class="chapter-preview-shell">
-                <summary>Editorial notes</summary>
+              <details class="chapter-preview-shell chapter-review-section" data-review-section>
+                <summary>
+                  <span>Editorial notes</span>
+                  <span class="summary-meta">{{ card.risk_chips|length }} signals</span>
+                </summary>
                 <div class="story-bible-grid">
                   <div class="detail-item">
                     <span class="detail-label">Scores</span>
@@ -1160,8 +1247,11 @@
             {% endif %}
 
             {% if chapter.content %}
-              <details class="chapter-preview-shell">
-                <summary>Preview chapter text</summary>
+              <details class="chapter-preview-shell chapter-review-section" data-review-section>
+                <summary>
+                  <span>Preview chapter text</span>
+                  <span class="summary-meta">{{ chapter.word_count or "Draft" }}{% if chapter.word_count %} words{% endif %}</span>
+                </summary>
                 <pre class="chapter-preview">{{ chapter.content }}</pre>
               </details>
             {% endif %}

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -465,6 +465,8 @@ def test_failed_run_detail_surfaces_recovery_guidance(client, monkeypatch) -> No
     assert "Stopped during Outline" in response.text
     assert "Outline returned 29 chapters, but 64 were required." in response.text
     assert "Review outputs and recovery actions" in response.text
+    assert "Recovery next step" in response.text
+    assert "Run again" in response.text
 
 
 def test_run_detail_renders_outline_approval_controls(client, monkeypatch) -> None:
@@ -640,6 +642,21 @@ def test_run_detail_surfaces_qa_report_artifact(client, monkeypatch) -> None:
     assert response.status_code == 200
     assert "editorial feedback" in response.text
     assert "qa-report.md" in response.text
+    assert "Editorial next step" in response.text
+    assert "Download QA report" in response.text
+    assert "Publication export" in response.text
+
+
+def test_completed_run_next_step_links_compare_when_available(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
+    _, run_ids = seed_project_with_completed_compare_runs()
+
+    response = client.get(f"/runs/{run_ids[0]}")
+
+    assert response.status_code == 200
+    assert "Editorial next step" in response.text
+    assert "Compare completed drafts" in response.text
+    assert "2 completed drafts" in response.text
 
 
 def test_completed_run_can_create_publication_export(client, monkeypatch) -> None:
@@ -777,6 +794,14 @@ def test_run_detail_surfaces_rich_chapter_qa_notes(client, monkeypatch) -> None:
     response = client.get(f"/runs/{run_id}")
 
     assert response.status_code == 200
+    assert "QA risk" in response.text
+    assert "Revision required" in response.text
+    assert "Weak ending" in response.text
+    assert "Technical fatigue" in response.text
+    assert "Continuity" in response.text
+    assert "Outcome logged" in response.text
+    assert "Trust fracture" in response.text
+    assert "data-review-section" in response.text
     assert "Blocking issues" in response.text
     assert "Repair scope" in response.text
     assert "Ending concreteness: 4/10" in response.text


### PR DESCRIPTION
## Summary

This is PR 3 in the Run Confidence First UI/UX series, stacked on #25.

- Adds a post-run editorial next-step panel for completed, failed, and canceled runs with QA download, compare, publication export, rerun, top-risk, and regenerate-from-chapter guidance.
- Adds compact chapter review rows for status, QA risk, and continuity signals so completed runs are easier to scan before expanding prose or notes.
- Tightens review-section collapse behavior and visual polish for buttons, chips, panel density, focus states, mobile wrapping, and long operational content.
- Adds UI route coverage for completed-run next steps, failed-run recovery guidance, compare availability, and chapter QA/continuity chips.

## Validation

- `python -m pytest tests/test_ui_routes.py` passed: 30 passed.
- `python -m pytest` passed: 110 passed.
- Visual smoke checked dashboard, project detail, completed run detail, failed run detail, outline approval, provider settings, and compare pages at desktop and mobile widths with no overflow/clipping or console errors.

## Notes

The browser visual check used a local Playwright fallback because the in-app Browser connector could not write its kernel assets in this session. Docker was unavailable, so tests were run with the local disposable Python environment used for this workspace.