### PR TITLE
[codex] Remove obsolete compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   web:
     build:


### PR DESCRIPTION
## Summary

- Removes the obsolete top-level `version` key from `docker-compose.yml`.
- Keeps the service definitions unchanged while silencing the Docker Compose warning printed during deploy/status commands.

## Validation

- `docker compose ps` succeeds without the obsolete-version warning.
- Full container test suite was run after the merged UI stack before this config-only cleanup: `docker compose exec -T web python -m pytest` passed with 110 tests.