### PR TITLE
[codex] Add checkpoint resume recovery

### DIFF
--- a/src/novel_generator/repositories.py
+++ b/src/novel_generator/repositories.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timedelta
 
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session, selectinload
@@ -136,6 +136,7 @@ def get_run(session: Session, run_id: str) -> GenerationRun | None:
             selectinload(GenerationRun.chapters),
             selectinload(GenerationRun.artifacts),
             selectinload(GenerationRun.events),
+            selectinload(GenerationRun.stage_attempts),
         )
     )
     return session.scalar(stmt)
@@ -425,7 +426,7 @@ def create_chapters_from_outline(session: Session, run: GenerationRun) -> list[C
     return created
 
 
-def claim_next_queued_run(session: Session) -> GenerationRun | None:
+def claim_next_queued_run(session: Session, worker_id: str | None = None) -> GenerationRun | None:
     stmt = (
         select(GenerationRun)
         .where(GenerationRun.status == RunStatus.QUEUED, GenerationRun.cancel_requested.is_(False))
@@ -438,21 +439,46 @@ def claim_next_queued_run(session: Session) -> GenerationRun | None:
     run.status = RunStatus.RUNNING
     run.current_step = "starting"
     run.started_at = run.started_at or datetime.utcnow()
+    run.worker_id = worker_id
+    run.last_heartbeat_at = datetime.utcnow()
     run.error_message = None
     session.flush()
     record_event(session, run, "run_started", {"message": "Worker claimed the run."})
     return run
 
 
-def recover_running_runs(session: Session) -> int:
-    runs = list(session.scalars(select(GenerationRun).where(GenerationRun.status == RunStatus.RUNNING)))
+def touch_run_heartbeat(session: Session, run: GenerationRun) -> None:
+    run.last_heartbeat_at = datetime.utcnow()
+    session.flush()
+
+
+def recover_running_runs(
+    session: Session,
+    *,
+    stale_after_seconds: int | None = None,
+    reason: str = "worker_startup",
+) -> int:
+    stmt = select(GenerationRun).where(GenerationRun.status == RunStatus.RUNNING)
+    if stale_after_seconds is not None:
+        cutoff = datetime.utcnow() - timedelta(seconds=stale_after_seconds)
+        stmt = stmt.where(
+            (GenerationRun.last_heartbeat_at.is_(None)) | (GenerationRun.last_heartbeat_at < cutoff)
+        )
+    runs = list(session.scalars(stmt))
     for run in runs:
         run.status = RunStatus.QUEUED
         run.current_step = "recovered"
+        run.worker_id = None
+        run.last_heartbeat_at = None
+        run.recovery_count += 1
         record_event(
             session,
             run,
             "run_requeued",
-            {"message": "Run was re-queued after an interrupted worker."},
+            {
+                "message": "Run was re-queued after an interrupted worker.",
+                "recovery_reason": reason,
+                "recovery_count": run.recovery_count,
+            },
         )
     return len(runs)

--- a/src/novel_generator/routers/api.py
+++ b/src/novel_generator/routers/api.py
@@ -41,7 +41,7 @@ from ..schemas import (
 )
 from ..services.provider_errors import ProviderError, ProviderTransportError
 from ..services.providers import ProviderManager, provider_definition
-from ..services.state import approve_outline_review, request_run_cancellation
+from ..services.state import approve_outline_review, request_run_cancellation, resume_failed_run
 from ..services.storage import delete_run_artifacts_dir, delete_run_artifacts_dirs
 from ..settings import Settings
 
@@ -421,6 +421,20 @@ def api_rerun(
     db.commit()
     new_run = get_run(db, new_run.id)
     return GenerationRunRead.model_validate(new_run)
+
+
+@router.post("/runs/{run_id}/resume", response_model=GenerationRunRead)
+def api_resume_run(run_id: str, db: Session = Depends(get_db)) -> GenerationRunRead:
+    run = get_run(db, run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found.")
+    try:
+        resume_failed_run(db, run)
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    db.commit()
+    run = get_run(db, run.id)
+    return GenerationRunRead.model_validate(run)
 
 
 @router.get("/runs/{run_id}/events")

--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -36,7 +36,7 @@ from ..services.ollama import OllamaClient
 from ..services.exports import export_publication_artifact, publication_export_options
 from ..services.provider_errors import ProviderError, ProviderTransportError
 from ..services.providers import ProviderManager, TASK_ROUTE_STAGES, provider_definition, provider_options
-from ..services.state import approve_outline_review, request_run_cancellation
+from ..services.state import approve_outline_review, request_run_cancellation, resume_failed_run
 from ..services.storage import delete_run_artifacts_dir, delete_run_artifacts_dirs
 from ..settings import Settings
 
@@ -1728,6 +1728,24 @@ def _chapter_review_cards(run: GenerationRun) -> list[dict[str, Any]]:
     ]
 
 
+def _run_attempt_diagnostics(run: GenerationRun) -> list[dict[str, Any]]:
+    attempts = sorted(getattr(run, "stage_attempts", []) or [], key=lambda item: (item.started_at, item.id))
+    failed = [attempt for attempt in attempts if attempt.status == "failed"]
+    source = failed[-5:] if failed else attempts[-5:]
+    return [
+        {
+            "stage": attempt.stage.replace("_", " "),
+            "chapter_number": attempt.chapter_number,
+            "status": attempt.status,
+            "provider_name": attempt.provider_name,
+            "model_name": attempt.model_name,
+            "error": attempt.error_message or "",
+            "duration_ms": attempt.duration_ms,
+        }
+        for attempt in source
+    ]
+
+
 def _run_editorial_next_step_context(run: GenerationRun, chapter_cards: list[dict[str, Any]]) -> dict[str, Any]:
     show = run.status in TERMINAL_STATUSES
     comparison_card = _run_comparison_card(run)
@@ -1799,6 +1817,8 @@ def _run_editorial_next_step_context(run: GenerationRun, chapter_cards: list[dic
         "compare_available": run.status == RunStatus.COMPLETED and len(completed_runs) >= 2,
         "comparison_run_count": len(completed_runs),
         "publication_available": run.status == RunStatus.COMPLETED,
+        "resume_available": run.status == RunStatus.FAILED,
+        "attempt_diagnostics": _run_attempt_diagnostics(run),
     }
 
 
@@ -2985,6 +3005,23 @@ def rerun_ui(
     )
     db.commit()
     return _redirect(f"/runs/{new_run.id}", message="Run re-queued.", message_tone="success")
+
+
+@router.post("/runs/{run_id}/resume")
+def resume_run_ui(run_id: str, db: Session = Depends(get_db)):
+    run = get_run(db, run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail="Run not found.")
+    try:
+        resume_failed_run(db, run)
+    except ValueError as exc:
+        return _redirect(f"/runs/{run.id}", message=str(exc), message_tone="warning")
+    db.commit()
+    return _redirect(
+        f"/runs/{run.id}",
+        message="Run queued to resume from the latest checkpoint.",
+        message_tone="success",
+    )
 
 
 @router.post("/runs/{run_id}/delete")

--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -15,11 +15,13 @@ from ..repositories import (
     fail_stage_attempt,
     record_event,
     replace_artifacts,
+    touch_run_heartbeat,
 )
 from ..schemas import (
     ChapterContinuityUpdate,
     ChapterCritique,
     ChapterPlan,
+    ChapterStoryTurn,
     CanonicalEntity,
     ContinuityBibleRow,
     ContinuityLedger,
@@ -204,9 +206,11 @@ def _ledger_with_chapter_mode(
 
 def _ensure_not_canceled(session: Session, run: GenerationRun) -> None:
     session.refresh(run)
+    touch_run_heartbeat(session, run)
     if run.cancel_requested:
         run.status = RunStatus.CANCELED
         run.current_step = "canceled"
+        run.worker_id = None
         run.completed_at = datetime.utcnow()
         record_event(session, run, "run_canceled", {"message": "Cancellation was requested."})
         session.commit()
@@ -275,14 +279,17 @@ def _supervised_provider_chat(
         model_name=model_name,
         metadata=metadata,
     )
+    touch_run_heartbeat(session, run)
     session.commit()
     try:
         output = _provider_chat(client, provider_name, model_name, messages, stream=stream)
     except Exception as exc:
         fail_stage_attempt(session, attempt, exc)
+        touch_run_heartbeat(session, run)
         session.commit()
         raise
     complete_stage_attempt(session, attempt, output)
+    touch_run_heartbeat(session, run)
     session.commit()
     return output
 
@@ -430,6 +437,24 @@ def _persist_structured_plan(chapter: Any, plan: ChapterPlan) -> None:
 
 def _persist_structured_qa(chapter: Any, critique: ChapterCritique) -> None:
     chapter.qa_notes = critique.model_dump()
+
+
+def _checkpointed_plan(chapter: Any) -> ChapterPlan | None:
+    if not chapter.plan:
+        return None
+    try:
+        return ChapterPlan.model_validate(json.loads(chapter.plan))
+    except Exception:
+        return None
+
+
+def _checkpointed_critique(chapter: Any) -> ChapterCritique | None:
+    if not chapter.qa_notes:
+        return None
+    try:
+        return ChapterCritique.model_validate(chapter.qa_notes)
+    except Exception:
+        return None
 
 
 def _resolve_repair_scope(*scopes: str) -> str:
@@ -773,6 +798,122 @@ def _fallback_outline_entries(
     return entries
 
 
+def _fallback_chapter_plan(
+    chapter: Any,
+    outline_entry: StructuredOutlineEntry,
+    story_bible: StoryBible,
+) -> ChapterPlan:
+    protagonist = story_bible.cast[0].name if story_bible.cast else "The protagonist"
+    support = story_bible.cast[1].name if len(story_bible.cast) > 1 else "a supporting character"
+    return ChapterPlan(
+        chapter_mode=outline_entry.chapter_mode,
+        opening_state=outline_entry.objective,
+        character_goal=f"{protagonist} pursues the chapter objective without losing agency.",
+        scene_beats=[
+            outline_entry.objective,
+            outline_entry.conflict_turn,
+            outline_entry.character_turn,
+            outline_entry.reveal,
+            outline_entry.ending_state,
+        ],
+        conflict_turn=outline_entry.conflict_turn,
+        ending_hook=outline_entry.concrete_ending_hook.trigger,
+        attempt=outline_entry.objective,
+        complication=outline_entry.primary_obstacle,
+        price_paid=outline_entry.cost_if_success,
+        partial_failure_mode=outline_entry.outcome_type,
+        ending_hook_delivery=outline_entry.concrete_ending_hook.next_problem,
+        emotional_anchor=outline_entry.emotional_reveal,
+        civilian_texture=outline_entry.civilian_life_detail,
+        ideology_clash=outline_entry.ideology_pressure,
+        primary_interpersonal_conflict=outline_entry.side_character_friction,
+        independent_side_character_move=outline_entry.independent_side_character_move
+        or f"{support} makes an independent pressure move.",
+        genre_specific_focus=outline_entry.chapter_mode,
+        genre_specific_beats=[outline_entry.civilian_life_detail, outline_entry.ideology_pressure],
+        story_turn=ChapterStoryTurn(
+            irreversible_change=outline_entry.ending_state,
+            protagonist_choice=outline_entry.character_turn,
+            choice_alternatives=[outline_entry.primary_obstacle, outline_entry.cost_if_success],
+            permanent_consequence=outline_entry.cost_if_success,
+            why_this_chapter_cannot_be_cut=outline_entry.reveal,
+            state_before=outline_entry.objective,
+            state_after=outline_entry.ending_state,
+        ),
+    )
+
+
+def _fallback_chapter_critique(chapter: Any, lint_result: ChapterLintResult) -> ChapterCritique:
+    findings = lint_result.combined_findings()
+    return ChapterCritique(
+        strengths=["Checkpoint fallback critique used local lint signals."],
+        warnings=findings,
+        revision_required=bool(findings),
+        focus=findings[:3],
+        ending_hook_type="unknown",
+        forward_motion_score=7 if not findings else 5,
+        ending_concreteness_score=7 if not findings else 5,
+        scene_turn_resolution_score=7 if not findings else 5,
+        cost_consequence_realism_score=7 if not findings else 5,
+        side_character_independence_score=7,
+        proper_noun_continuity_score=8,
+        repetition_risk_score=0 if not findings else 5,
+        emotional_depth_score=7,
+        ideology_clarity_score=7,
+        civilian_texture_score=7,
+        blocking_issues=findings[:3],
+        soft_warnings=findings[3:],
+        repair_scope="targeted_scene_and_ending" if findings else "none",
+    )
+
+
+def _fallback_chapter_summary(chapter: Any, outline_entry: StructuredOutlineEntry, plan: ChapterPlan) -> str:
+    prose_words = (chapter.content or "").split()
+    excerpt = " ".join(prose_words[:80]).strip()
+    if excerpt:
+        return (
+            f"Chapter {chapter.chapter_number} follows {outline_entry.objective}. "
+            f"The planned turn is {plan.story_turn.irreversible_change or outline_entry.ending_state}. "
+            f"Draft excerpt: {excerpt}"
+        )
+    return (
+        f"Chapter {chapter.chapter_number} follows {outline_entry.objective} and ends with "
+        f"{outline_entry.ending_state}."
+    )
+
+
+def _fallback_continuity_update(
+    chapter: Any,
+    ledger: ContinuityLedger,
+    outline_entry: StructuredOutlineEntry,
+    plan: ChapterPlan,
+) -> ChapterContinuityUpdate:
+    timeline_entry = f"Chapter {chapter.chapter_number}: {chapter.summary or outline_entry.ending_state}"
+    return ChapterContinuityUpdate(
+        chapter_outcome=outline_entry.ending_state,
+        current_patch_status=ledger.current_patch_status,
+        character_states=dict(ledger.character_states),
+        world_state=ledger.world_state or outline_entry.ending_state,
+        open_threads=_dedupe([*ledger.open_threads, outline_entry.concrete_ending_hook.next_problem]),
+        resolved_threads=list(ledger.resolved_threads),
+        timeline_entry=timeline_entry,
+        timeline=_dedupe([*ledger.timeline, timeline_entry]),
+        new_entities_introduced=[],
+        entity_state_changes={},
+        open_promises_by_name=dict(ledger.open_promises_by_name),
+        ideology_state_by_character=dict(ledger.ideology_state_by_character),
+        ideology_shift_notes={},
+        memory_damage=dict(ledger.memory_damage),
+        trust_fractures=dict(ledger.trust_fractures),
+        civilian_pressure_points=_dedupe([*ledger.civilian_pressure_points, outline_entry.civilian_life_detail]),
+        emotional_open_loops=dict(ledger.emotional_open_loops),
+        side_character_decisions=dict(ledger.side_character_decisions),
+        story_turn=plan.story_turn,
+        genre_state=dict(ledger.genre_state),
+        system_state_transitions=[],
+    )
+
+
 def _validated_outline_or_fallback(
     session: Session,
     project: Any,
@@ -1008,115 +1149,175 @@ def _draft_chapter(
     ledger = _continuity_ledger_from_run(run)
     prior_chapters = _chapter_prior_context(run, chapter.chapter_number)
     _sync_summary_context(run, settings.chapter_summary_window)
-    plan_provider_name, plan_model_name = _resolve_stage_route(client, run, "chapter_plan")
     run.current_chapter = chapter.chapter_number
-    run.current_step = "chapter_plan"
-    record_event(
-        session,
-        run,
-        "chapter_planning",
-        {
-            "chapter_number": chapter.chapter_number,
-            "title": chapter.title,
-            "provider_name": plan_provider_name,
-            "model_name": plan_model_name,
-        },
-    )
-    session.commit()
 
-    plan = _generate_structured_output(
-        session,
-        run,
-        client,
-        plan_provider_name,
-        plan_model_name,
-        lambda: build_chapter_plan_messages(
-            project,
-            run,
-            chapter,
-            outline_entry,
-            story_bible,
-            ledger,
-            run.summary_context or "",
-        ),
-        parse_chapter_plan,
-        f"chapter {chapter.chapter_number} plan",
-        "chapter_plan",
-        chapter.chapter_number,
-    )
-    _persist_structured_plan(chapter, plan)
-    session.commit()
-
-    _ensure_not_canceled(session, run)
-    draft_provider_name, draft_model_name = _resolve_stage_route(client, run, "chapter_draft")
-    run.current_step = "chapter_draft"
-    record_event(
-        session,
-        run,
-        "chapter_drafting",
-        {
-            "chapter_number": chapter.chapter_number,
-            "title": chapter.title,
-            "provider_name": draft_provider_name,
-            "model_name": draft_model_name,
-        },
-    )
-    session.commit()
-
-    chapter.content = sanitize_chapter_content(
-        _supervised_provider_chat(
+    plan = _checkpointed_plan(chapter)
+    if plan is None:
+        plan_provider_name, plan_model_name = _resolve_stage_route(client, run, "chapter_plan")
+        run.current_step = "chapter_plan"
+        record_event(
             session,
             run,
-            client,
-            draft_provider_name,
-            draft_model_name,
-            build_chapter_draft_messages(
-                project,
-                run,
-                chapter,
-                outline_entry,
-                story_bible,
-                ledger,
-                run.summary_context or "",
-                plan,
-            ),
-            stage="chapter_draft",
-            chapter_number=chapter.chapter_number,
-            metadata={"label": f"chapter {chapter.chapter_number} draft"},
+            "chapter_planning",
+            {
+                "chapter_number": chapter.chapter_number,
+                "title": chapter.title,
+                "provider_name": plan_provider_name,
+                "model_name": plan_model_name,
+            },
         )
-    )
-    if not chapter.content.strip():
-        raise RuntimeError(f"Chapter {chapter.chapter_number} draft was empty.")
-    chapter.word_count = len((chapter.content or "").split())
-    session.commit()
+        session.commit()
+
+        try:
+            plan = _generate_structured_output(
+                session,
+                run,
+                client,
+                plan_provider_name,
+                plan_model_name,
+                lambda: build_chapter_plan_messages(
+                    project,
+                    run,
+                    chapter,
+                    outline_entry,
+                    story_bible,
+                    ledger,
+                    run.summary_context or "",
+                ),
+                parse_chapter_plan,
+                f"chapter {chapter.chapter_number} plan",
+                "chapter_plan",
+                chapter.chapter_number,
+            )
+        except Exception as exc:
+            plan = _fallback_chapter_plan(chapter, outline_entry, story_bible)
+            record_event(
+                session,
+                run,
+                "chapter_plan_fallback",
+                {
+                    "message": f"Chapter {chapter.chapter_number} plan used deterministic fallback.",
+                    "chapter_number": chapter.chapter_number,
+                    "error": str(exc),
+                },
+            )
+        _persist_structured_plan(chapter, plan)
+        session.commit()
+    else:
+        record_event(
+            session,
+            run,
+            "chapter_plan_checkpoint_reused",
+            {"message": f"Reused saved plan for chapter {chapter.chapter_number}.", "chapter_number": chapter.chapter_number},
+        )
+        session.commit()
 
     _ensure_not_canceled(session, run)
-    critique_provider_name, critique_model_name = _resolve_stage_route(client, run, "chapter_critique")
+    if not (chapter.content or "").strip():
+        draft_provider_name, draft_model_name = _resolve_stage_route(client, run, "chapter_draft")
+        run.current_step = "chapter_draft"
+        record_event(
+            session,
+            run,
+            "chapter_drafting",
+            {
+                "chapter_number": chapter.chapter_number,
+                "title": chapter.title,
+                "provider_name": draft_provider_name,
+                "model_name": draft_model_name,
+            },
+        )
+        session.commit()
+
+        chapter.content = sanitize_chapter_content(
+            _supervised_provider_chat(
+                session,
+                run,
+                client,
+                draft_provider_name,
+                draft_model_name,
+                build_chapter_draft_messages(
+                    project,
+                    run,
+                    chapter,
+                    outline_entry,
+                    story_bible,
+                    ledger,
+                    run.summary_context or "",
+                    plan,
+                ),
+                stage="chapter_draft",
+                chapter_number=chapter.chapter_number,
+                metadata={"label": f"chapter {chapter.chapter_number} draft"},
+            )
+        )
+        if not chapter.content.strip():
+            raise RuntimeError(f"Chapter {chapter.chapter_number} draft was empty.")
+        chapter.word_count = len((chapter.content or "").split())
+        session.commit()
+    else:
+        chapter.word_count = len((chapter.content or "").split())
+        record_event(
+            session,
+            run,
+            "chapter_draft_checkpoint_reused",
+            {"message": f"Reused saved draft for chapter {chapter.chapter_number}.", "chapter_number": chapter.chapter_number},
+        )
+        session.commit()
+
+    _ensure_not_canceled(session, run)
     run.current_step = "chapter_revision"
     lint_result = lint_chapter(chapter, outline_entry, plan, story_bible, ledger, prior_chapters)
-    critique = _generate_structured_output(
-        session,
-        run,
-        client,
-        critique_provider_name,
-        critique_model_name,
-        lambda: build_chapter_critique_messages(
-            project,
-            chapter,
-            outline_entry,
-            story_bible,
-            ledger,
-            plan,
-            lint_result.combined_findings(),
-        ),
-        parse_chapter_critique,
-        f"chapter {chapter.chapter_number} critique",
-        "chapter_critique",
-        chapter.chapter_number,
-    )
-    combined_critique = _combine_chapter_feedback(critique, lint_result)
-    _persist_structured_qa(chapter, combined_critique)
-    session.commit()
+    combined_critique = _checkpointed_critique(chapter)
+    critique_provider_name, critique_model_name = _resolve_stage_route(client, run, "chapter_critique")
+    if combined_critique is None:
+        try:
+            critique = _generate_structured_output(
+                session,
+                run,
+                client,
+                critique_provider_name,
+                critique_model_name,
+                lambda: build_chapter_critique_messages(
+                    project,
+                    chapter,
+                    outline_entry,
+                    story_bible,
+                    ledger,
+                    plan,
+                    lint_result.combined_findings(),
+                ),
+                parse_chapter_critique,
+                f"chapter {chapter.chapter_number} critique",
+                "chapter_critique",
+                chapter.chapter_number,
+            )
+        except Exception as exc:
+            critique = _fallback_chapter_critique(chapter, lint_result)
+            record_event(
+                session,
+                run,
+                "chapter_critique_fallback",
+                {
+                    "message": f"Chapter {chapter.chapter_number} critique used local lint fallback.",
+                    "chapter_number": chapter.chapter_number,
+                    "error": str(exc),
+                },
+            )
+        combined_critique = _combine_chapter_feedback(critique, lint_result)
+        _persist_structured_qa(chapter, combined_critique)
+        session.commit()
+    else:
+        record_event(
+            session,
+            run,
+            "chapter_critique_checkpoint_reused",
+            {
+                "message": f"Reused saved critique for chapter {chapter.chapter_number}.",
+                "chapter_number": chapter.chapter_number,
+            },
+        )
+        session.commit()
 
     if combined_critique.revision_required:
         record_event(
@@ -1164,60 +1365,114 @@ def _draft_chapter(
         session.commit()
 
         final_lint = lint_chapter(chapter, outline_entry, plan, story_bible, ledger, prior_chapters)
-        final_critique = _generate_structured_output(
-            session,
-            run,
-            client,
-            critique_provider_name,
-            critique_model_name,
-            lambda: build_chapter_critique_messages(
-                project,
-                chapter,
-                outline_entry,
-                story_bible,
-                ledger,
-                plan,
-                final_lint.combined_findings(),
-            ),
-            parse_chapter_critique,
-            f"chapter {chapter.chapter_number} post-repair critique",
-            "chapter_critique",
-            chapter.chapter_number,
-        )
+        try:
+            final_critique = _generate_structured_output(
+                session,
+                run,
+                client,
+                critique_provider_name,
+                critique_model_name,
+                lambda: build_chapter_critique_messages(
+                    project,
+                    chapter,
+                    outline_entry,
+                    story_bible,
+                    ledger,
+                    plan,
+                    final_lint.combined_findings(),
+                ),
+                parse_chapter_critique,
+                f"chapter {chapter.chapter_number} post-repair critique",
+                "chapter_critique",
+                chapter.chapter_number,
+            )
+        except Exception as exc:
+            final_critique = _fallback_chapter_critique(chapter, final_lint)
+            record_event(
+                session,
+                run,
+                "chapter_critique_fallback",
+                {
+                    "message": f"Chapter {chapter.chapter_number} post-repair critique used local lint fallback.",
+                    "chapter_number": chapter.chapter_number,
+                    "error": str(exc),
+                },
+            )
         combined_critique = _combine_chapter_feedback(final_critique, final_lint)
         _persist_structured_qa(chapter, combined_critique)
         session.commit()
 
     _ensure_not_canceled(session, run)
-    summary_provider_name, summary_model_name = _resolve_stage_route(client, run, "chapter_summary")
-    run.current_step = "chapter_summary"
-    chapter.summary = _supervised_provider_chat(
-        session,
-        run,
-        client,
-        summary_provider_name,
-        summary_model_name,
-        build_summary_messages(chapter, outline_entry),
-        stage="chapter_summary",
-        chapter_number=chapter.chapter_number,
-        metadata={"label": f"chapter {chapter.chapter_number} summary"},
-    ).strip()
-    if not chapter.summary:
-        raise RuntimeError(f"Chapter {chapter.chapter_number} summary was empty.")
+    if not (chapter.summary or "").strip():
+        summary_provider_name, summary_model_name = _resolve_stage_route(client, run, "chapter_summary")
+        run.current_step = "chapter_summary"
+        try:
+            chapter.summary = _supervised_provider_chat(
+                session,
+                run,
+                client,
+                summary_provider_name,
+                summary_model_name,
+                build_summary_messages(chapter, outline_entry),
+                stage="chapter_summary",
+                chapter_number=chapter.chapter_number,
+                metadata={"label": f"chapter {chapter.chapter_number} summary"},
+            ).strip()
+            if not chapter.summary:
+                raise RuntimeError(f"Chapter {chapter.chapter_number} summary was empty.")
+        except Exception as exc:
+            chapter.summary = _fallback_chapter_summary(chapter, outline_entry, plan)
+            record_event(
+                session,
+                run,
+                "chapter_summary_fallback",
+                {
+                    "message": f"Chapter {chapter.chapter_number} summary used deterministic fallback.",
+                    "chapter_number": chapter.chapter_number,
+                    "error": str(exc),
+                },
+            )
+        session.commit()
 
-    continuity_provider_name, continuity_model_name = _resolve_stage_route(client, run, "continuity_update")
-    continuity_update = _generate_structured_output(
-        session,
-        run,
-        client,
-        continuity_provider_name,
-        continuity_model_name,
-        lambda: build_continuity_update_messages(project, chapter, ledger, story_bible),
-        parse_continuity_update,
-        f"chapter {chapter.chapter_number} continuity update",
-        "continuity_update",
-        chapter.chapter_number,
-    )
+    if chapter.continuity_update:
+        continuity_update = ChapterContinuityUpdate.model_validate(chapter.continuity_update)
+        record_event(
+            session,
+            run,
+            "continuity_checkpoint_reused",
+            {
+                "message": f"Reused saved continuity update for chapter {chapter.chapter_number}.",
+                "chapter_number": chapter.chapter_number,
+            },
+        )
+    else:
+        continuity_provider_name, continuity_model_name = _resolve_stage_route(client, run, "continuity_update")
+        run.current_step = "continuity_update"
+        try:
+            continuity_update = _generate_structured_output(
+                session,
+                run,
+                client,
+                continuity_provider_name,
+                continuity_model_name,
+                lambda: build_continuity_update_messages(project, chapter, ledger, story_bible),
+                parse_continuity_update,
+                f"chapter {chapter.chapter_number} continuity update",
+                "continuity_update",
+                chapter.chapter_number,
+            )
+        except Exception as exc:
+            continuity_update = _fallback_continuity_update(chapter, ledger, outline_entry, plan)
+            record_event(
+                session,
+                run,
+                "continuity_update_fallback",
+                {
+                    "message": f"Chapter {chapter.chapter_number} continuity used deterministic fallback.",
+                    "chapter_number": chapter.chapter_number,
+                    "error": str(exc),
+                },
+            )
     ledger_after = _ledger_from_update(ledger, continuity_update)
     ledger_after = _ledger_with_chapter_mode(ledger_after, chapter.chapter_number, outline_entry.chapter_mode)
     if continuity_update.timeline != ledger_after.timeline:
@@ -1536,6 +1791,7 @@ def process_run(session: Session, run: GenerationRun, settings: Settings, client
     run.current_step = "completed"
     run.current_chapter = None
     run.status = RunStatus.COMPLETED
+    run.worker_id = None
     run.completed_at = datetime.utcnow()
     record_event(
         session,
@@ -1559,6 +1815,7 @@ def process_run_safe(session: Session, run: GenerationRun, settings: Settings, c
                 chapter.error_message = str(exc)
         run.status = RunStatus.FAILED
         run.current_step = "failed"
+        run.worker_id = None
         run.error_message = str(exc)
         run.completed_at = datetime.utcnow()
         record_event(session, run, "run_failed", {"message": str(exc)})
@@ -1571,6 +1828,7 @@ def process_run_safe(session: Session, run: GenerationRun, settings: Settings, c
                 chapter.error_message = str(exc)
         run.status = RunStatus.FAILED
         run.current_step = "failed"
+        run.worker_id = None
         run.error_message = str(exc)
         run.completed_at = datetime.utcnow()
         record_event(session, run, "run_failed", {"message": str(exc)})

--- a/src/novel_generator/services/runner.py
+++ b/src/novel_generator/services/runner.py
@@ -17,7 +17,11 @@ logger = logging.getLogger(__name__)
 def recover_incomplete_runs(settings: Settings) -> None:
     session_factory = build_session_factory(settings)
     with session_factory() as session:
-        count = recover_running_runs(session, reason="worker_startup")
+        count = recover_running_runs(
+            session,
+            stale_after_seconds=settings.run_stale_after_seconds,
+            reason="worker_startup",
+        )
         session.commit()
         if count:
             logger.info("Recovered %s interrupted runs.", count)

--- a/src/novel_generator/services/runner.py
+++ b/src/novel_generator/services/runner.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import socket
 import time
 
 from ..db import build_session_factory
@@ -15,7 +17,7 @@ logger = logging.getLogger(__name__)
 def recover_incomplete_runs(settings: Settings) -> None:
     session_factory = build_session_factory(settings)
     with session_factory() as session:
-        count = recover_running_runs(session)
+        count = recover_running_runs(session, reason="worker_startup")
         session.commit()
         if count:
             logger.info("Recovered %s interrupted runs.", count)
@@ -23,9 +25,17 @@ def recover_incomplete_runs(settings: Settings) -> None:
 
 def run_worker_loop(settings: Settings) -> None:
     session_factory = build_session_factory(settings)
+    worker_id = f"{socket.gethostname()}:{os.getpid()}"
     while True:
         with session_factory() as session:
-            run = claim_next_queued_run(session)
+            stale_count = recover_running_runs(
+                session,
+                stale_after_seconds=settings.run_stale_after_seconds,
+                reason="stale_heartbeat",
+            )
+            if stale_count:
+                logger.warning("Recovered %s stale running runs.", stale_count)
+            run = claim_next_queued_run(session, worker_id=worker_id)
             session.commit()
             if run is None:
                 time.sleep(settings.worker_poll_interval_seconds)

--- a/src/novel_generator/services/state.py
+++ b/src/novel_generator/services/state.py
@@ -29,3 +29,26 @@ def approve_outline_review(session: Session, run: GenerationRun) -> GenerationRu
     run.cancel_requested = False
     record_event(session, run, "outline_approved", {"message": "Outline approved. Run re-queued for drafting."})
     return run
+
+
+def resume_failed_run(session: Session, run: GenerationRun) -> GenerationRun:
+    if run.status != RunStatus.FAILED:
+        raise ValueError("Only failed runs can be resumed from checkpoint.")
+    run.status = RunStatus.QUEUED
+    run.current_step = "queued"
+    run.error_message = None
+    run.completed_at = None
+    run.cancel_requested = False
+    run.worker_id = None
+    run.last_heartbeat_at = None
+    run.recovery_count += 1
+    record_event(
+        session,
+        run,
+        "run_resume_queued",
+        {
+            "message": "Run queued to resume from the latest saved checkpoint.",
+            "recovery_count": run.recovery_count,
+        },
+    )
+    return run

--- a/src/novel_generator/static/style.css
+++ b/src/novel_generator/static/style.css
@@ -1291,6 +1291,22 @@ dd {
   background: rgba(255, 255, 255, 0.58);
 }
 
+.attempt-diagnostic-list {
+  display: grid;
+  gap: 0.65rem;
+}
+
+.attempt-diagnostic {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.75rem;
+  border: 1px solid rgba(217, 207, 192, 0.95);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.58);
+}
+
 .artifact-kind {
   text-transform: uppercase;
   letter-spacing: 0.08em;

--- a/src/novel_generator/templates/run_detail.html
+++ b/src/novel_generator/templates/run_detail.html
@@ -497,8 +497,13 @@
         {% if editorial_next_step.publication_available %}
           <a class="button secondary" href="#publication-export">Publication export</a>
         {% endif %}
+        {% if editorial_next_step.resume_available %}
+          <form method="post" action="/runs/{{ run.id }}/resume">
+            <button type="submit">Resume from checkpoint</button>
+          </form>
+        {% endif %}
         <form method="post" action="/runs/{{ run.id }}/rerun">
-          <button type="submit">Run again</button>
+          <button class="{% if editorial_next_step.resume_available %}secondary{% endif %}" type="submit">Run again</button>
         </form>
       </div>
     </div>
@@ -543,6 +548,25 @@
           {% endif %}
         </div>
       </div>
+      {% if editorial_next_step.attempt_diagnostics %}
+        <div class="detail-item">
+          <span class="detail-label">Attempt diagnostics</span>
+          <div class="attempt-diagnostic-list">
+            {% for attempt in editorial_next_step.attempt_diagnostics %}
+              <div class="attempt-diagnostic">
+                <span class="badge status-{{ 'failed' if attempt.status == 'failed' else 'completed' }}">{{ attempt.status }}</span>
+                <div>
+                  <strong>{{ attempt.stage }}{% if attempt.chapter_number %} / chapter {{ attempt.chapter_number }}{% endif %}</strong>
+                  <p class="field-note">{{ attempt.provider_name }} / {{ attempt.model_name }}{% if attempt.duration_ms is not none %} / {{ attempt.duration_ms }}ms{% endif %}</p>
+                  {% if attempt.error %}
+                    <p class="error-text">{{ attempt.error }}</p>
+                  {% endif %}
+                </div>
+              </div>
+            {% endfor %}
+          </div>
+        </div>
+      {% endif %}
     </div>
   </section>
 {% endif %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -200,6 +200,36 @@ def test_rerun_api_requeues_same_settings_as_v2_run(client, monkeypatch) -> None
     assert rerun_response.json()["id"] != run_id
 
 
+def test_resume_failed_run_api_requeues_same_run(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "list_models", lambda self: ["test-model"])
+
+    _, run_id = create_project_and_run(client)
+    with get_session_factory()() as session:
+        run = get_run(session, run_id)
+        assert run is not None
+        run.status = RunStatus.FAILED
+        run.current_step = "failed"
+        run.error_message = "Draft provider disconnected."
+        session.commit()
+
+    response = client.post(f"/api/runs/{run_id}/resume")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["id"] == run_id
+    assert payload["status"] == "queued"
+    assert payload["error_message"] is None
+    assert payload["recovery_count"] == 1
+
+
+def test_resume_run_api_rejects_non_failed_run(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "list_models", lambda self: ["test-model"])
+
+    _, run_id = create_project_and_run(client)
+
+    response = client.post(f"/api/runs/{run_id}/resume")
+    assert response.status_code == 409
+
+
 def test_approve_outline_api_requeues_paused_run(client, monkeypatch) -> None:
     monkeypatch.setattr(OllamaClient, "list_models", lambda self: ["test-model"])
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -8,6 +8,7 @@ from novel_generator.models import ChapterStatus, RunStatus
 from novel_generator.repositories import create_project, create_run, get_run, list_stage_attempts, recover_running_runs
 from novel_generator.schemas import ProjectCreate, RunCreate
 from novel_generator.services.pipeline import process_run_safe
+from novel_generator.services.runner import recover_incomplete_runs
 from novel_generator.services.state import approve_outline_review, resume_failed_run
 from novel_generator.settings import get_settings
 
@@ -1308,4 +1309,30 @@ def test_recover_running_runs_uses_stale_heartbeat_threshold(configured_environm
         assert recovered == 1
         assert refreshed_stale.status == RunStatus.QUEUED
         assert refreshed_stale.events[-1].payload["recovery_reason"] == "stale_heartbeat"
+        assert refreshed_fresh.status == RunStatus.RUNNING
+
+
+def test_worker_startup_recovery_only_requeues_stale_runs(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=2)
+        stale = create_run(session, project, RunCreate(project_id=project.id, model_name="test-model"))
+        stale.status = RunStatus.RUNNING
+        stale.last_heartbeat_at = datetime.utcnow() - timedelta(seconds=7200)
+        fresh = create_run(session, project, RunCreate(project_id=project.id, model_name="test-model"))
+        fresh.status = RunStatus.RUNNING
+        fresh.last_heartbeat_at = datetime.utcnow()
+        session.commit()
+
+        stale_id = stale.id
+        fresh_id = fresh.id
+
+    recover_incomplete_runs(settings)
+
+    with session_factory() as session:
+        refreshed_stale = get_run(session, stale_id)
+        refreshed_fresh = get_run(session, fresh_id)
+        assert refreshed_stale.status == RunStatus.QUEUED
+        assert refreshed_stale.events[-1].payload["recovery_reason"] == "worker_startup"
         assert refreshed_fresh.status == RunStatus.RUNNING

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timedelta
 
 from novel_generator.dependencies import get_session_factory
 from novel_generator.models import ChapterStatus, RunStatus
 from novel_generator.repositories import create_project, create_run, get_run, list_stage_attempts, recover_running_runs
 from novel_generator.schemas import ProjectCreate, RunCreate
 from novel_generator.services.pipeline import process_run_safe
-from novel_generator.services.state import approve_outline_review
+from novel_generator.services.state import approve_outline_review, resume_failed_run
 from novel_generator.settings import get_settings
 
 
@@ -495,6 +496,137 @@ def test_stage_attempts_are_recorded_for_failed_provider_calls(configured_enviro
         assert attempts[0].status == "failed"
         assert attempts[0].error_type == "RuntimeError"
         assert "provider unavailable" in (attempts[0].error_message or "")
+
+
+def test_failed_draft_can_resume_from_saved_chapter_plan(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=1)
+        run = create_run(
+            session,
+            project,
+            RunCreate(project_id=project.id, model_name="test-model", pause_after_outline=False),
+        )
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient([_story_bible_json(), _outline_json(1), _plan_json(1), RuntimeError("draft down")]),
+        )
+
+        failed = get_run(session, run.id)
+        assert failed is not None
+        assert failed.status == RunStatus.FAILED
+        assert failed.chapters[0].plan is not None
+        assert failed.chapters[0].content is None
+
+        resume_failed_run(session, failed)
+        session.commit()
+        process_run_safe(
+            session,
+            failed,
+            settings,
+            FakeOllamaClient(
+                [
+                    "Iris slips out of the archive while Tarin resists following her. Trigger 1 arrives when the visible actor 1 seals the corridor, leaving only route 1 below them.",
+                    _critique_json(revision_required=False),
+                    "Iris chooses the lower route and accepts the cost of leaving the archive behind.",
+                    _continuity_json(1),
+                    _qa_report_json(),
+                ]
+            ),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed is not None
+        assert refreshed.status == RunStatus.COMPLETED
+        attempts = list_stage_attempts(session, run.id)
+        assert sum(attempt.stage == "chapter_plan" for attempt in attempts) == 1
+        assert any(event.event_type == "run_resume_queued" for event in refreshed.events)
+        assert any(event.event_type == "chapter_plan_checkpoint_reused" for event in refreshed.events)
+
+
+def test_summary_fallback_completes_run_when_summary_provider_fails(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=1)
+        run = create_run(
+            session,
+            project,
+            RunCreate(project_id=project.id, model_name="test-model", pause_after_outline=False),
+        )
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient(
+                [
+                    _story_bible_json(),
+                    _outline_json(1),
+                    _plan_json(1),
+                    "Iris slips out of the archive while Tarin resists following her. Trigger 1 arrives when the visible actor 1 seals the corridor, leaving only route 1 below them.",
+                    _critique_json(revision_required=False),
+                    RuntimeError("summary down"),
+                    _continuity_json(1),
+                    _qa_report_json(),
+                ]
+            ),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed is not None
+        assert refreshed.status == RunStatus.COMPLETED
+        assert any(event.event_type == "chapter_summary_fallback" for event in refreshed.events)
+        assert refreshed.chapters[0].summary
+
+
+def test_continuity_fallback_completes_run_when_continuity_provider_fails(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=1)
+        run = create_run(
+            session,
+            project,
+            RunCreate(project_id=project.id, model_name="test-model", pause_after_outline=False),
+        )
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient(
+                [
+                    _story_bible_json(),
+                    _outline_json(1),
+                    _plan_json(1),
+                    "Iris slips out of the archive while Tarin resists following her. Trigger 1 arrives when the visible actor 1 seals the corridor, leaving only route 1 below them.",
+                    _critique_json(revision_required=False),
+                    "Iris chooses the lower route and accepts the cost of leaving the archive behind.",
+                    RuntimeError("continuity down"),
+                    _qa_report_json(),
+                ]
+            ),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed is not None
+        assert refreshed.status == RunStatus.COMPLETED
+        assert any(event.event_type == "continuity_update_fallback" for event in refreshed.events)
+        assert refreshed.chapters[0].continuity_update
 
 
 def test_large_run_generates_outline_in_chunks_and_pauses(configured_environment) -> None:
@@ -1152,3 +1284,28 @@ def test_recover_running_runs_marks_runs_as_queued(configured_environment) -> No
         refreshed = get_run(session, run.id)
         assert recovered == 1
         assert refreshed.status.value == "queued"
+        assert refreshed.recovery_count == 1
+        assert refreshed.events[-1].payload["recovery_reason"] == "worker_startup"
+
+
+def test_recover_running_runs_uses_stale_heartbeat_threshold(configured_environment) -> None:
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=2)
+        stale = create_run(session, project, RunCreate(project_id=project.id, model_name="test-model"))
+        stale.status = RunStatus.RUNNING
+        stale.last_heartbeat_at = datetime.utcnow() - timedelta(seconds=7200)
+        fresh = create_run(session, project, RunCreate(project_id=project.id, model_name="test-model"))
+        fresh.status = RunStatus.RUNNING
+        fresh.last_heartbeat_at = datetime.utcnow()
+        session.commit()
+
+        recovered = recover_running_runs(session, stale_after_seconds=3600, reason="stale_heartbeat")
+        session.commit()
+
+        refreshed_stale = get_run(session, stale.id)
+        refreshed_fresh = get_run(session, fresh.id)
+        assert recovered == 1
+        assert refreshed_stale.status == RunStatus.QUEUED
+        assert refreshed_stale.events[-1].payload["recovery_reason"] == "stale_heartbeat"
+        assert refreshed_fresh.status == RunStatus.RUNNING

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -5,7 +5,16 @@ import json
 
 from novel_generator.dependencies import get_session_factory
 from novel_generator.models import Artifact, ChapterStatus, RunStatus
-from novel_generator.repositories import create_chapters_from_outline, create_project, create_run, get_project, get_run, record_event
+from novel_generator.repositories import (
+    begin_stage_attempt,
+    create_chapters_from_outline,
+    create_project,
+    create_run,
+    fail_stage_attempt,
+    get_project,
+    get_run,
+    record_event,
+)
 from novel_generator.schemas import ProjectCreate, ProviderCapabilities, RunCreate
 from novel_generator.services.ollama import OllamaClient
 from novel_generator.settings import get_settings
@@ -457,6 +466,16 @@ def test_failed_run_detail_surfaces_recovery_guidance(client, monkeypatch) -> No
         run.status = RunStatus.FAILED
         run.current_step = "outline"
         run.error_message = "Outline returned 29 chapters, but 64 were required."
+        attempt = begin_stage_attempt(
+            session,
+            run,
+            stage="outline",
+            chapter_number=None,
+            provider_name="ollama",
+            model_name="test-model",
+            metadata={"label": "structured outline"},
+        )
+        fail_stage_attempt(session, attempt, RuntimeError("Outline returned 29 chapters, but 64 were required."))
         session.commit()
 
     response = client.get(f"/runs/{run_id}")
@@ -466,6 +485,8 @@ def test_failed_run_detail_surfaces_recovery_guidance(client, monkeypatch) -> No
     assert "Outline returned 29 chapters, but 64 were required." in response.text
     assert "Review outputs and recovery actions" in response.text
     assert "Recovery next step" in response.text
+    assert "Resume from checkpoint" in response.text
+    assert "Attempt diagnostics" in response.text
     assert "Run again" in response.text
 
 


### PR DESCRIPTION
## Summary

PR 2 of the Reliability-First Long-Run Hardening stack, stacked on #28.

- Adds checkpoint-aware processing so saved plans, drafts, critiques, summaries, and continuity updates can be reused when resuming a failed run.
- Adds deterministic fallbacks for chapter plans, critiques, summaries, and continuity updates while keeping prose draft/revision failures terminal and resumable.
- Adds `POST /api/runs/{run_id}/resume` plus failed-run UI controls for resuming the same run from its latest checkpoint.
- Adds worker heartbeat/recovery metadata usage, including stale heartbeat recovery events.
- Surfaces attempt diagnostics on failed run pages.

## Validation

- `docker compose exec -T web python -m pytest tests/test_api.py tests/test_pipeline.py tests/test_ui_routes.py` passed: 67 passed.
- `docker compose exec -T web python -m pytest` passed: 119 passed.