### PR TITLE
Add long-run preflight and quality profiles

### DIFF
--- a/alembic/versions/0006_quality_profiles.py
+++ b/alembic/versions/0006_quality_profiles.py
@@ -1,0 +1,23 @@
+"""quality profiles for generation runs"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0006_quality_profiles"
+down_revision = "0005_run_resilience"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "generation_runs",
+        sa.Column("quality_profile", sa.String(length=32), nullable=False, server_default="balanced"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("generation_runs", "quality_profile")

--- a/src/novel_generator/models.py
+++ b/src/novel_generator/models.py
@@ -89,6 +89,7 @@ class GenerationRun(Base):
     pipeline_version: Mapped[int] = mapped_column(Integer, default=1)
     pause_after_outline: Mapped[bool] = mapped_column(Boolean, default=True)
     developmental_rewrite_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    quality_profile: Mapped[str] = mapped_column(String(32), default="balanced")
     status: Mapped[RunStatus] = mapped_column(Enum(RunStatus), default=RunStatus.QUEUED)
     current_step: Mapped[str] = mapped_column(String(255), default="queued")
     current_chapter: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/src/novel_generator/repositories.py
+++ b/src/novel_generator/repositories.py
@@ -186,6 +186,8 @@ def create_run(session: Session, project: Project, payload: RunCreate) -> Genera
     min_words_per_chapter = payload.min_words_per_chapter or project.min_words_per_chapter
     max_words_per_chapter = payload.max_words_per_chapter or project.max_words_per_chapter
     task_routing = _normalized_task_routing(payload.task_routing) if payload.task_routing is not None else deepcopy(project.task_routing or {})
+    quality_profile = payload.quality_profile or "balanced"
+    developmental_rewrite_enabled = payload.developmental_rewrite_enabled or quality_profile == "strict"
 
     if not provider_name:
         raise ValueError("A provider name is required.")
@@ -204,7 +206,8 @@ def create_run(session: Session, project: Project, payload: RunCreate) -> Genera
         max_words_per_chapter=max_words_per_chapter,
         pipeline_version=2,
         pause_after_outline=payload.pause_after_outline,
-        developmental_rewrite_enabled=payload.developmental_rewrite_enabled,
+        developmental_rewrite_enabled=developmental_rewrite_enabled,
+        quality_profile=quality_profile,
         task_routing=task_routing,
         status=RunStatus.QUEUED,
         current_step="queued",

--- a/src/novel_generator/routers/api.py
+++ b/src/novel_generator/routers/api.py
@@ -134,6 +134,7 @@ def _same_settings_payload(run, *, pause_after_outline: bool = True) -> RunCreat
         max_words_per_chapter=run.max_words_per_chapter,
         pause_after_outline=pause_after_outline,
         developmental_rewrite_enabled=run.developmental_rewrite_enabled,
+        quality_profile=run.quality_profile,
         task_routing=run.task_routing or {},
     )
 

--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -29,7 +29,15 @@ from ..repositories import (
     update_project,
     update_provider_config,
 )
-from ..schemas import CanonicalEntity, ProjectCreate, ProjectUpdate, ProviderCapabilities, ProviderConfigUpdate, RunCreate
+from ..schemas import (
+    QUALITY_PROFILE_VALUES,
+    CanonicalEntity,
+    ProjectCreate,
+    ProjectUpdate,
+    ProviderCapabilities,
+    ProviderConfigUpdate,
+    RunCreate,
+)
 from ..services.genre_profiles import genre_profile, genre_profile_options
 from ..services.openai_compatible import OpenAICompatibleClient
 from ..services.ollama import OllamaClient
@@ -168,6 +176,29 @@ HIGH_TOKEN_DISCLOSURE = (
     "Full novel runs can use large prompts, chapter drafts, critiques, and QA payloads. "
     "Expect high token usage if the configured provider charges by token."
 )
+PREFLIGHT_OUTLINE_CHUNK_THRESHOLD = 32
+PREFLIGHT_OUTLINE_CHUNK_SIZE = 8
+QUALITY_PROFILE_DEFS = [
+    {
+        "value": "balanced",
+        "label": "Balanced",
+        "summary": "Current behavior",
+        "description": "Use the existing revision thresholds and keep developmental rewrite planning optional.",
+    },
+    {
+        "value": "draft",
+        "label": "Draft",
+        "summary": "Fastest full manuscript",
+        "description": "Defer non-blocking polish repairs so long runs reach a complete draft sooner.",
+    },
+    {
+        "value": "strict",
+        "label": "Strict",
+        "summary": "Most editorial scrutiny",
+        "description": "Use tighter revision thresholds and include developmental rewrite planning by default.",
+    },
+]
+QUALITY_PROFILE_LOOKUP = {item["value"]: item for item in QUALITY_PROFILE_DEFS}
 RUN_STAGE_LOOKUP = {stage["id"]: stage for stage in RUN_STAGES}
 RUN_STAGE_PROGRESS_ORDER = [
     "queued",
@@ -1245,6 +1276,7 @@ def _run_form_values(project: Project, values: dict[str, Any] | None = None) -> 
         "max_words_per_chapter": project.max_words_per_chapter,
         "pause_after_outline": True,
         "developmental_rewrite_enabled": False,
+        "quality_profile": "balanced",
         **_task_routing_form_values(project.task_routing),
     }
     if values:
@@ -1307,6 +1339,139 @@ def _form_route_privacy_summary(
         str(values.get(model_field, "") or ""),
         _task_routing_payload(values),
     )
+
+
+def _quality_profile_context(value: Any) -> dict[str, str]:
+    key = str(value or "balanced").strip().lower().replace("-", "_").replace(" ", "_")
+    if key not in QUALITY_PROFILE_VALUES:
+        key = "balanced"
+    return QUALITY_PROFILE_LOOKUP[key]
+
+
+def _quality_profile_options(selected: Any) -> list[dict[str, Any]]:
+    selected_key = _quality_profile_context(selected)["value"]
+    return [
+        {
+            **option,
+            "selected": option["value"] == selected_key,
+        }
+        for option in QUALITY_PROFILE_DEFS
+    ]
+
+
+def _positive_int(value: Any, fallback: int) -> int:
+    try:
+        parsed = int(str(value).strip())
+    except (TypeError, ValueError):
+        return max(1, fallback)
+    return max(1, parsed)
+
+
+def _run_preflight_context(
+    values: dict[str, Any],
+    settings: Settings,
+    configs_by_name: dict[str, Any],
+    statuses_by_name: dict[str, ProviderCapabilities],
+) -> dict[str, Any]:
+    provider_name = str(values.get("provider_name") or "ollama").strip() or "ollama"
+    model_name = str(values.get("model_name") or "").strip()
+    requested_chapters = _positive_int(values.get("requested_chapters"), 1)
+    target_word_count = _positive_int(values.get("target_word_count"), 1)
+    pause_after_outline = bool(values.get("pause_after_outline", True))
+    profile = _quality_profile_context(values.get("quality_profile"))
+    developmental_rewrite_enabled = bool(values.get("developmental_rewrite_enabled")) or profile["value"] == "strict"
+    task_routing = _task_routing_payload(values)
+    route_disclosure = _route_privacy_summary(provider_name, model_name, task_routing)
+    config = configs_by_name.get(provider_name)
+    provider_status = statuses_by_name.get(provider_name)
+
+    outline_chunks = (
+        1
+        if requested_chapters <= PREFLIGHT_OUTLINE_CHUNK_THRESHOLD
+        else max(1, (requested_chapters + PREFLIGHT_OUTLINE_CHUNK_SIZE - 1) // PREFLIGHT_OUTLINE_CHUNK_SIZE)
+    )
+    estimated_model_calls = 1 + outline_chunks + (requested_chapters * 5) + 1
+    if developmental_rewrite_enabled:
+        estimated_model_calls += 1
+
+    warnings: list[dict[str, str]] = []
+    if config is None:
+        warnings.append({"tone": "error", "message": "The selected provider is not configured."})
+    elif not config.is_enabled:
+        warnings.append({"tone": "error", "message": f"{provider_definition(provider_name).label} is disabled."})
+
+    if provider_status is None:
+        warnings.append({"tone": "error", "message": "Provider reachability has not been checked yet."})
+    elif not provider_status.reachable:
+        warnings.append(
+            {
+                "tone": "error",
+                "message": provider_status.error or f"{provider_definition(provider_name).label} is not reachable.",
+            }
+        )
+    elif provider_status.available_models and model_name not in provider_status.available_models:
+        warnings.append({"tone": "warning", "message": f"Model '{model_name}' is not in the detected model list."})
+
+    if requested_chapters > PREFLIGHT_OUTLINE_CHUNK_THRESHOLD:
+        warnings.append(
+            {
+                "tone": "warning",
+                "message": f"{requested_chapters} chapters will use {outline_chunks} outline chunks to reduce long-outline failures.",
+            }
+        )
+    if requested_chapters >= 64:
+        warnings.append(
+            {
+                "tone": "warning",
+                "message": "High chapter counts make checkpoint resume and outline review especially important.",
+            }
+        )
+    if route_disclosure["is_external"]:
+        warnings.append(
+            {
+                "tone": "warning",
+                "message": "One or more stages use an external route; verify cost and data-retention expectations before queueing.",
+            }
+        )
+    if not pause_after_outline:
+        warnings.append(
+            {
+                "tone": "warning",
+                "message": "Outline approval is disabled, so drafting will begin as soon as the outline is generated.",
+            }
+        )
+
+    has_error = any(item["tone"] == "error" for item in warnings)
+    has_warning = any(item["tone"] == "warning" for item in warnings)
+    tone = "error" if has_error else ("warning" if has_warning else "success")
+    status_label = "Blocked" if has_error else ("Review" if has_warning else "Ready")
+    provider_label = provider_definition(provider_name).label if config is not None else provider_name
+    model_status = "Detected"
+    if provider_status is None or not provider_status.available_models:
+        model_status = "No detected model list"
+    elif model_name not in provider_status.available_models:
+        model_status = "Not detected"
+
+    return {
+        "tone": tone,
+        "status_label": status_label,
+        "summary": "Provider, model, outline scale, and recovery guardrails checked before queueing.",
+        "warnings": warnings,
+        "rows": [
+            {"label": "Provider route", "value": f"{provider_label} / {model_name or '-'}"},
+            {"label": "Model reachability", "value": "Reachable" if provider_status and provider_status.reachable else "Unavailable"},
+            {"label": "Model status", "value": model_status},
+            {"label": "Outline chunks", "value": str(outline_chunks)},
+            {"label": "Estimated model calls", "value": f"{estimated_model_calls} minimum"},
+            {"label": "Quality profile", "value": profile["label"]},
+            {"label": "Target length", "value": f"{requested_chapters} chapters / {target_word_count} words"},
+        ],
+        "recovery_features": [
+            "Stage attempt ledger",
+            "Checkpoint resume",
+            f"Stale heartbeat recovery after {max(1, settings.run_stale_after_seconds // 60)} minutes",
+        ],
+    }
 
 
 def _provider_catalog(settings: Settings, db: Session) -> tuple[dict[str, Any], dict[str, ProviderCapabilities], ProviderManager]:
@@ -1978,6 +2143,13 @@ def _project_detail_context(
         "project_run_rows": [_run_row_context(run) for run in run_stats["project_runs"]],
         "run_values": run_payload,
         "run_errors": run_errors or {},
+        "quality_profile_options": _quality_profile_options(run_payload.get("quality_profile")),
+        "run_preflight": _run_preflight_context(
+            run_payload,
+            settings,
+            provider_configs_by_name,
+            provider_statuses_by_name,
+        ),
         "run_task_route_rows": _task_route_rows(run_payload),
         "run_route_disclosure": _form_route_privacy_summary(
             run_payload,
@@ -2054,6 +2226,7 @@ def _same_settings_payload(run: GenerationRun, *, source_run_id: str | None = No
         max_words_per_chapter=run.max_words_per_chapter,
         pause_after_outline=True,
         developmental_rewrite_enabled=run.developmental_rewrite_enabled,
+        quality_profile=run.quality_profile,
         task_routing=run.task_routing or {},
         source_run_id=source_run_id,
         resume_from_chapter=resume_from_chapter,
@@ -2697,6 +2870,7 @@ def create_run_ui(
     max_words_per_chapter: str = Form(""),
     pause_after_outline: str | None = Form(None),
     developmental_rewrite_enabled: str | None = Form(None),
+    quality_profile: str = Form("balanced"),
     db: Session = Depends(get_db),
     settings: Settings = Depends(get_app_settings),
 ):
@@ -2713,6 +2887,7 @@ def create_run_ui(
         "max_words_per_chapter": max_words_per_chapter,
         "pause_after_outline": _coerce_checkbox(pause_after_outline),
         "developmental_rewrite_enabled": _coerce_checkbox(developmental_rewrite_enabled),
+        "quality_profile": quality_profile,
     }
     provider_configs_by_name, provider_statuses_by_name, manager = _provider_catalog(settings, db)
 
@@ -2801,6 +2976,7 @@ def run_detail(
             "run": run,
             "project": run.project,
             "run_genre_profile": run_profile,
+            "quality_profile": _quality_profile_context(run.quality_profile),
             "show_rerun": run.status in TERMINAL_STATUSES,
             "terminal_statuses": TERMINAL_STATUSES,
             "run_stages": RUN_STAGES,

--- a/src/novel_generator/schemas.py
+++ b/src/novel_generator/schemas.py
@@ -10,6 +10,8 @@ from .models import ChapterStatus, RunStatus
 from .services.genre_profiles import DEFAULT_GENRE_PROFILE, GENRE_PROFILES
 
 
+QUALITY_PROFILE_VALUES = {"draft", "balanced", "strict"}
+
 ALLOWED_CHAPTER_MODES = {
     "investigation",
     "interpersonal_confrontation",
@@ -86,6 +88,13 @@ def _validate_genre_profile(value: Any) -> str:
     key = str(value or DEFAULT_GENRE_PROFILE).strip() or DEFAULT_GENRE_PROFILE
     if key not in GENRE_PROFILES:
         raise ValueError("Choose one of the supported genre profiles.")
+    return key
+
+
+def _validate_quality_profile(value: Any) -> str:
+    key = str(value or "balanced").strip().lower().replace("-", "_").replace(" ", "_")
+    if key not in QUALITY_PROFILE_VALUES:
+        raise ValueError("Choose draft, balanced, or strict.")
     return key
 
 
@@ -921,9 +930,15 @@ class RunCreate(BaseModel):
     max_words_per_chapter: int | None = Field(default=None, ge=1)
     pause_after_outline: bool = True
     developmental_rewrite_enabled: bool = False
+    quality_profile: str = "balanced"
     task_routing: TaskRouting | None = None
     source_run_id: str | None = None
     resume_from_chapter: int | None = Field(default=None, ge=1)
+
+    @field_validator("quality_profile", mode="before")
+    @classmethod
+    def validate_quality_profile(cls, value: Any) -> str:
+        return _validate_quality_profile(value)
 
 
 class GenerationRunRead(BaseModel):
@@ -941,6 +956,7 @@ class GenerationRunRead(BaseModel):
     pipeline_version: int
     pause_after_outline: bool
     developmental_rewrite_enabled: bool
+    quality_profile: str
     status: RunStatus
     current_step: str
     current_chapter: int | None

--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -475,6 +475,7 @@ STYLE_SCORE_LABELS = {
     "dialogue_tension_score": "dialogue tension",
 }
 STYLE_REPAIR_THRESHOLD = 5
+STRICT_STYLE_REPAIR_THRESHOLD = 6
 
 
 def _style_score_warnings(critique: ChapterCritique) -> list[str]:
@@ -494,6 +495,9 @@ TECHNICAL_FATIGUE_REPAIR_THRESHOLD = 6
 SIDE_CHARACTER_REPAIR_THRESHOLD = 5
 STORY_TURN_REPAIR_THRESHOLD = 5
 CUTTABLE_CHAPTER_REPAIR_THRESHOLD = 6
+STRICT_LOW_SCORE_THRESHOLD = 6
+STRICT_TECHNICAL_FATIGUE_THRESHOLD = 5
+STRICT_CUTTABLE_CHAPTER_THRESHOLD = 5
 
 
 def _ending_score_warnings(critique: ChapterCritique) -> list[str]:
@@ -596,6 +600,86 @@ def _combine_chapter_feedback(critique: ChapterCritique, lint_result: ChapterLin
             "blocking_issues": blocking_issues,
             "soft_warnings": soft_warnings,
             "repair_scope": repair_scope,
+        }
+    )
+
+
+def _strict_quality_warnings(critique: ChapterCritique) -> tuple[list[str], list[str]]:
+    warnings: list[str] = []
+    scopes: list[str] = []
+
+    weak_style_scores = [
+        f"{label} {getattr(critique, field)}/10"
+        for field, label in STYLE_SCORE_LABELS.items()
+        if getattr(critique, field) <= STRICT_STYLE_REPAIR_THRESHOLD
+    ]
+    if weak_style_scores:
+        warnings.append("Strict profile wants stronger prose delivery: " + ", ".join(weak_style_scores) + ".")
+        scopes.append("voice_and_texture")
+
+    low_score_checks = [
+        ("ending_concreteness_score", "ending concreteness"),
+        ("scene_turn_resolution_score", "scene turn resolution"),
+        ("cost_consequence_realism_score", "cost/consequence realism"),
+        ("side_character_independence_score", "side-character independence"),
+        ("irreversibility_score", "irreversibility"),
+        ("choice_clarity_score", "choice clarity"),
+    ]
+    for field, label in low_score_checks:
+        score = int(getattr(critique, field) or 0)
+        if score <= STRICT_LOW_SCORE_THRESHOLD:
+            warnings.append(f"Strict profile requires a repair for {label} at {score}/10.")
+            scopes.append("targeted_scene_and_ending")
+
+    if critique.technical_escalation_fatigue_score >= STRICT_TECHNICAL_FATIGUE_THRESHOLD:
+        warnings.append(
+            "Strict profile wants technical escalation pressure reduced: "
+            f"fatigue score {critique.technical_escalation_fatigue_score}/10."
+        )
+        scopes.append("targeted_scene_and_ending")
+
+    if critique.cuttable_chapter_risk_score >= STRICT_CUTTABLE_CHAPTER_THRESHOLD:
+        warnings.append(
+            "Strict profile wants a more load-bearing chapter turn: "
+            f"cuttable risk {critique.cuttable_chapter_risk_score}/10."
+        )
+        scopes.append("targeted_scene_and_ending")
+
+    return warnings, scopes
+
+
+def _apply_quality_profile_to_critique(run: GenerationRun, critique: ChapterCritique) -> ChapterCritique:
+    profile = str(getattr(run, "quality_profile", "balanced") or "balanced").strip().lower()
+    if profile == "draft":
+        if critique.blocking_issues or critique.repair_scope == "full_chapter":
+            return critique
+        draft_note = "Draft profile deferred non-blocking revision work to keep the long run moving."
+        return critique.model_copy(
+            update={
+                "warnings": _dedupe([*critique.warnings, draft_note]),
+                "soft_warnings": _dedupe([*critique.soft_warnings, draft_note]),
+                "revision_required": False,
+                "repair_scope": "none",
+            }
+        )
+
+    if profile != "strict":
+        return critique
+
+    strict_warnings, scopes = _strict_quality_warnings(critique)
+    if not strict_warnings:
+        return critique
+
+    soft_warnings = _dedupe([*critique.soft_warnings, *strict_warnings])
+    warnings = _dedupe([*critique.warnings, *strict_warnings])
+    focus = _dedupe([*critique.focus, *strict_warnings[:3]])
+    return critique.model_copy(
+        update={
+            "warnings": warnings,
+            "soft_warnings": soft_warnings,
+            "focus": focus,
+            "revision_required": True,
+            "repair_scope": _resolve_repair_scope(critique.repair_scope, *scopes),
         }
     )
 
@@ -1304,7 +1388,10 @@ def _draft_chapter(
                     "error": str(exc),
                 },
             )
-        combined_critique = _combine_chapter_feedback(critique, lint_result)
+        combined_critique = _apply_quality_profile_to_critique(
+            run,
+            _combine_chapter_feedback(critique, lint_result),
+        )
         _persist_structured_qa(chapter, combined_critique)
         session.commit()
     else:
@@ -1398,7 +1485,10 @@ def _draft_chapter(
                     "error": str(exc),
                 },
             )
-        combined_critique = _combine_chapter_feedback(final_critique, final_lint)
+        combined_critique = _apply_quality_profile_to_critique(
+            run,
+            _combine_chapter_feedback(final_critique, final_lint),
+        )
         _persist_structured_qa(chapter, combined_critique)
         session.commit()
 

--- a/src/novel_generator/static/style.css
+++ b/src/novel_generator/static/style.css
@@ -29,6 +29,8 @@
 body {
   margin: 0;
   min-height: 100vh;
+  max-width: 100%;
+  overflow-x: hidden;
   color: var(--ink);
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   line-height: 1.55;
@@ -85,6 +87,7 @@ summary:focus-visible {
 .shell-header,
 .shell-main {
   width: min(1200px, calc(100% - 2rem));
+  max-width: calc(100vw - 2rem);
   margin: 0 auto;
 }
 
@@ -324,6 +327,14 @@ textarea:focus-visible {
   flex-wrap: wrap;
   gap: 0.65rem;
   align-items: center;
+  min-width: 0;
+}
+
+.hero-actions form,
+.form-actions form,
+.panel-actions form {
+  min-width: 0;
+  max-width: 100%;
 }
 
 .grid {
@@ -1624,6 +1635,8 @@ code {
 .story-card,
 .outline-card,
 .toggle-card,
+.quality-profile-option,
+.preflight-card,
 .story-brief-shell,
 .model-picker,
 .chapter-preview,
@@ -1714,6 +1727,72 @@ code {
   padding: 0.72rem 0.85rem;
 }
 
+.quality-profile-section {
+  gap: 0.85rem;
+}
+
+.quality-profile-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.quality-profile-option {
+  gap: 0.55rem;
+  padding: 0.82rem;
+  border: 1px solid rgba(212, 221, 215, 0.95);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.58);
+  cursor: pointer;
+}
+
+.quality-profile-option.is-selected {
+  border-color: rgba(23, 106, 90, 0.5);
+  background: rgba(23, 106, 90, 0.08);
+}
+
+.quality-profile-option input {
+  width: auto;
+  margin: 0;
+}
+
+.preflight-card {
+  display: grid;
+  gap: 0.85rem;
+  padding: 0.95rem;
+  border: 1px solid rgba(212, 221, 215, 0.95);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.6);
+}
+
+.preflight-success {
+  border-color: rgba(18, 107, 63, 0.22);
+  background: rgba(18, 107, 63, 0.06);
+}
+
+.preflight-warning {
+  border-color: rgba(184, 126, 24, 0.28);
+  background: rgba(184, 126, 24, 0.07);
+}
+
+.preflight-error {
+  border-color: rgba(161, 58, 42, 0.24);
+  background: rgba(161, 58, 42, 0.07);
+}
+
+.preflight-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.preflight-warning-list {
+  margin: 0;
+  padding-left: 1.15rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
 .run-command-center {
   display: grid;
   gap: 0.75rem;
@@ -1752,7 +1831,7 @@ code {
 
 .run-status-strip {
   display: grid;
-  grid-template-columns: minmax(10rem, 1.25fr) repeat(5, minmax(7.2rem, 1fr));
+  grid-template-columns: minmax(10rem, 1.25fr) repeat(6, minmax(7.2rem, 1fr));
   gap: 0.65rem;
 }
 
@@ -1841,6 +1920,8 @@ code {
   .run-setup-grid,
   .run-status-strip,
   .run-meta-grid,
+  .quality-profile-grid,
+  .preflight-grid,
   .management-grid,
   .quick-action-grid,
   .stats-grid,
@@ -1879,6 +1960,12 @@ code {
     align-items: start;
   }
 
+  .hero-actions,
+  .form-actions,
+  .panel-actions {
+    width: 100%;
+  }
+
   .stack-panels {
     gap: 1rem;
   }
@@ -1915,7 +2002,8 @@ code {
 @media (max-width: 640px) {
   .shell-header,
   .shell-main {
-    width: min(1200px, calc(100% - 1.2rem));
+    width: calc(100vw - 1.2rem);
+    max-width: calc(100vw - 1.2rem);
   }
 
   .hero-card,
@@ -1958,5 +2046,39 @@ code {
     width: 100%;
     justify-content: flex-start;
     border-radius: var(--radius);
+  }
+
+  .hero-actions,
+  .form-actions,
+  .panel-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .page-header-copy,
+  .section-header-copy,
+  .callout-copy,
+  .chapter-heading {
+    width: min(100%, calc(100vw - 4rem));
+  }
+
+  .hero-copy {
+    max-width: 30ch;
+  }
+
+  .callout-copy h2 {
+    max-width: 24ch;
+  }
+
+  .hero-actions form,
+  .form-actions form,
+  .panel-actions form,
+  .hero-actions .button,
+  .form-actions .button,
+  .panel-actions .button,
+  .hero-actions button,
+  .form-actions button,
+  .panel-actions button {
+    width: 100%;
   }
 }

--- a/src/novel_generator/static/ui.js
+++ b/src/novel_generator/static/ui.js
@@ -2,6 +2,7 @@ document.addEventListener("DOMContentLoaded", () => {
   setupConfirmActions(document);
   setupModelPickers(document);
   setupRunModeNotes(document);
+  setupQualityProfileControls(document);
   setupOutlineReview(document);
   setupReviewSections(document);
   setupProviderConsole();
@@ -87,6 +88,37 @@ function setupRunModeNotes(root) {
       note.textContent = checkbox.checked ? note.dataset.pauseMessage || "" : note.dataset.straightMessage || "";
     };
     checkbox.addEventListener("change", sync);
+    sync();
+  });
+}
+
+function setupQualityProfileControls(root) {
+  const controls = Array.from(root.querySelectorAll("[data-quality-profile-control]"));
+  controls.forEach((control) => {
+    if (control.dataset.qualityProfileBound === "true") {
+      return;
+    }
+    control.dataset.qualityProfileBound = "true";
+    const form = control.closest("form");
+    const options = Array.from(control.querySelectorAll("[data-quality-profile-option]"));
+    const note = control.querySelector("[data-quality-profile-note]");
+    const rewriteToggle = form?.querySelector("[data-developmental-rewrite-toggle]");
+
+    const sync = () => {
+      const selected = options.find((option) => option.checked);
+      control.querySelectorAll(".quality-profile-option").forEach((label) => {
+        const input = label.querySelector("[data-quality-profile-option]");
+        label.classList.toggle("is-selected", Boolean(input?.checked));
+      });
+      if (note && selected) {
+        note.textContent = selected.dataset.profileNote || "";
+      }
+      if (rewriteToggle && selected?.value === "strict") {
+        rewriteToggle.checked = true;
+      }
+    };
+
+    options.forEach((option) => option.addEventListener("change", sync));
     sync();
   });
 }

--- a/src/novel_generator/templates/project_detail.html
+++ b/src/novel_generator/templates/project_detail.html
@@ -499,6 +499,36 @@
         </div>
       </div>
 
+      <div class="form-section run-cardlet quality-profile-section" data-quality-profile-control>
+        <div class="section-header-copy">
+          <h3>Quality profile</h3>
+          <p>Choose how aggressively this run should spend time on editorial repair passes.</p>
+        </div>
+        <div class="quality-profile-grid">
+          {% for option in quality_profile_options %}
+            <label class="quality-profile-option{% if option.selected %} is-selected{% endif %}">
+              <span class="toggle-input">
+                <input
+                  type="radio"
+                  name="quality_profile"
+                  value="{{ option.value }}"
+                  data-quality-profile-option
+                  data-profile-note="{{ option.description }}"
+                  {% if option.selected %}checked{% endif %}
+                >
+                <strong>{{ option.label }}</strong>
+              </span>
+              <span class="meta-chip">{{ option.summary }}</span>
+              <span class="field-note">{{ option.description }}</span>
+            </label>
+          {% endfor %}
+        </div>
+        {% if run_errors.quality_profile %}<p class="field-error">{{ run_errors.quality_profile }}</p>{% endif %}
+        <div class="inline-note inline-note-success" data-quality-profile-note>
+          {% for option in quality_profile_options %}{% if option.selected %}{{ option.description }}{% endif %}{% endfor %}
+        </div>
+      </div>
+
       <label class="toggle-card run-mode-card">
         <span class="toggle-input">
           <input type="checkbox" name="pause_after_outline" value="1" {% if run_values.pause_after_outline %}checked{% endif %}>
@@ -509,7 +539,7 @@
 
       <label class="toggle-card run-mode-card">
         <span class="toggle-input">
-          <input type="checkbox" name="developmental_rewrite_enabled" value="1" {% if run_values.developmental_rewrite_enabled %}checked{% endif %}>
+          <input data-developmental-rewrite-toggle type="checkbox" name="developmental_rewrite_enabled" value="1" {% if run_values.developmental_rewrite_enabled or run_values.quality_profile == "strict" %}checked{% endif %}>
           <strong>Run developmental rewrite planning</strong>
         </span>
         <span class="field-note">After manuscript QA, produce a structural rewrite report, revised outline, and QA comparison for merge, cut, bridge, reorder, or rewrite decisions.</span>
@@ -544,6 +574,35 @@
         {{ "Connected" if provider_status.reachable else "Unavailable" }}
       </span>
     </div>
+    <section class="preflight-card preflight-{{ run_preflight.tone }}" data-run-preflight>
+      <div class="section-header">
+        <div class="section-header-copy">
+          <h3>Run preflight</h3>
+          <p>{{ run_preflight.summary }}</p>
+        </div>
+        <span class="badge status-{{ 'failed' if run_preflight.tone == 'error' else ('running' if run_preflight.tone == 'success' else 'queued') }}">{{ run_preflight.status_label }}</span>
+      </div>
+      <div class="preflight-grid">
+        {% for row in run_preflight.rows %}
+          <div class="detail-item">
+            <span class="detail-label">{{ row.label }}</span>
+            <span class="detail-value long-value">{{ row.value }}</span>
+          </div>
+        {% endfor %}
+      </div>
+      <div class="meta-chip-row">
+        {% for feature in run_preflight.recovery_features %}
+          <span class="meta-chip">{{ feature }}</span>
+        {% endfor %}
+      </div>
+      {% if run_preflight.warnings %}
+        <ul class="preflight-warning-list">
+          {% for warning in run_preflight.warnings %}
+            <li class="alert-{{ warning.tone }}">{{ warning.message }}</li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </section>
     <div class="run-flow">
       <div class="section-header-copy">
         <h3>What a v2 run produces</h3>

--- a/src/novel_generator/templates/run_detail.html
+++ b/src/novel_generator/templates/run_detail.html
@@ -63,6 +63,11 @@
         <span class="field-note">Pipeline v{{ run.pipeline_version or 1 }}</span>
       </div>
       <div class="run-status-item">
+        <span class="detail-label">Profile</span>
+        <strong>{{ quality_profile.label }}</strong>
+        <span class="field-note">{{ quality_profile.summary }}</span>
+      </div>
+      <div class="run-status-item">
         <span class="detail-label">Words</span>
         <strong data-run-word-progress>{{ total_run_words }}</strong>
         <span class="field-note"><span data-run-word-progress-label>{{ word_progress_percent }}%</span> of {{ run.target_word_count }}</span>
@@ -123,6 +128,10 @@
         <div class="detail-item">
           <span class="detail-label">Genre profile</span>
           <span class="detail-value">{{ run_genre_profile.label }}</span>
+        </div>
+        <div class="detail-item">
+          <span class="detail-label">Quality profile</span>
+          <span class="detail-value">{{ quality_profile.label }} - {{ quality_profile.summary }}</span>
         </div>
         <div class="detail-item">
           <span class="detail-label">Queued</span>
@@ -466,6 +475,10 @@
       <div class="detail-item inline-detail">
         <span class="detail-label">Pause after outline</span>
         <span class="detail-value">{{ "Enabled" if run.pause_after_outline else "Consumed or disabled" }}</span>
+      </div>
+      <div class="detail-item inline-detail">
+        <span class="detail-label">Quality profile</span>
+        <span class="detail-value">{{ quality_profile.label }}</span>
       </div>
       <div class="detail-item inline-detail">
         <span class="detail-label">Per-task overrides</span>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,6 +40,7 @@ def create_project_and_run(
     *,
     pause_after_outline: bool = True,
     developmental_rewrite_enabled: bool = False,
+    quality_profile: str = "balanced",
 ) -> tuple[str, str]:
     project_response = client.post("/api/projects", json=create_project_payload())
     assert project_response.status_code == 201
@@ -52,6 +53,7 @@ def create_project_and_run(
             "model_name": "test-model",
             "pause_after_outline": pause_after_outline,
             "developmental_rewrite_enabled": developmental_rewrite_enabled,
+            "quality_profile": quality_profile,
         },
     )
     assert run_response.status_code == 201
@@ -68,6 +70,7 @@ def test_project_and_run_api_flow(client, monkeypatch) -> None:
     assert detail_response.json()["project_id"] == project_id
     assert detail_response.json()["pause_after_outline"] is True
     assert detail_response.json()["developmental_rewrite_enabled"] is False
+    assert detail_response.json()["quality_profile"] == "balanced"
 
     cancel_response = client.post(f"/api/runs/{run_id}/cancel")
     assert cancel_response.status_code == 200
@@ -172,6 +175,35 @@ def test_invalid_model_is_rejected_when_queueing_run(client, monkeypatch) -> Non
     assert "not available" in run_response.json()["detail"]
 
 
+def test_strict_quality_profile_enables_developmental_rewrite_by_default(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "list_models", lambda self: ["test-model"])
+
+    _, run_id = create_project_and_run(client, quality_profile="strict")
+
+    response = client.get(f"/api/runs/{run_id}")
+    assert response.status_code == 200
+    assert response.json()["quality_profile"] == "strict"
+    assert response.json()["developmental_rewrite_enabled"] is True
+
+
+def test_invalid_quality_profile_is_rejected_when_queueing_run(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "list_models", lambda self: ["test-model"])
+
+    project_response = client.post("/api/projects", json=create_project_payload())
+    project_id = project_response.json()["id"]
+
+    run_response = client.post(
+        "/api/runs",
+        json={
+            "project_id": project_id,
+            "model_name": "test-model",
+            "quality_profile": "maximum",
+        },
+    )
+
+    assert run_response.status_code == 422
+
+
 def test_rerun_api_requeues_same_settings_as_v2_run(client, monkeypatch) -> None:
     monkeypatch.setattr(OllamaClient, "list_models", lambda self: ["test-model"])
 
@@ -179,6 +211,7 @@ def test_rerun_api_requeues_same_settings_as_v2_run(client, monkeypatch) -> None
         client,
         pause_after_outline=False,
         developmental_rewrite_enabled=True,
+        quality_profile="strict",
     )
     session_factory = get_session_factory()
     with session_factory() as session:
@@ -197,6 +230,7 @@ def test_rerun_api_requeues_same_settings_as_v2_run(client, monkeypatch) -> None
     assert rerun_response.json()["pipeline_version"] == 2
     assert rerun_response.json()["pause_after_outline"] is True
     assert rerun_response.json()["developmental_rewrite_enabled"] is True
+    assert rerun_response.json()["quality_profile"] == "strict"
     assert rerun_response.json()["id"] != run_id
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+import sqlalchemy as sa
+
+from novel_generator.dependencies import get_session_factory, get_templates
+from novel_generator.settings import get_settings
+
+
+def _alembic_config() -> Config:
+    project_root = Path(__file__).resolve().parents[1]
+    config = Config(str(project_root / "alembic.ini"))
+    config.set_main_option("script_location", str(project_root / "alembic"))
+    return config
+
+
+def test_quality_profile_migration_defaults_existing_runs(tmp_path: Path, monkeypatch) -> None:
+    database_url = f"sqlite:///{(tmp_path / 'migration.db').as_posix()}"
+    monkeypatch.setenv("DATABASE_URL", database_url)
+    monkeypatch.setenv("ARTIFACTS_DIR", str(tmp_path / "artifacts"))
+    get_settings.cache_clear()
+    get_session_factory.cache_clear()
+    get_templates.cache_clear()
+
+    config = _alembic_config()
+    command.upgrade(config, "0005_run_resilience")
+
+    now = datetime.utcnow().isoformat()
+    engine = sa.create_engine(database_url)
+    with engine.begin() as connection:
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO projects (
+                    id, title, premise, desired_word_count, requested_chapters,
+                    min_words_per_chapter, max_words_per_chapter, preferred_model,
+                    notes, created_at, updated_at, story_brief, preferred_provider_name,
+                    task_routing
+                )
+                VALUES (
+                    'project-1', 'Migration Project', 'Premise', 4000, 4,
+                    800, 1200, 'test-model', NULL, :now, :now, '{}', 'ollama', '{}'
+                )
+                """
+            ),
+            {"now": now},
+        )
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO generation_runs (
+                    id, project_id, source_run_id, model_name, target_word_count,
+                    requested_chapters, min_words_per_chapter, max_words_per_chapter,
+                    status, current_step, current_chapter, outline, summary_context,
+                    error_message, cancel_requested, resume_from_chapter, created_at,
+                    started_at, completed_at, updated_at, pipeline_version,
+                    pause_after_outline, story_bible, continuity_ledger, provider_name,
+                    task_routing, developmental_rewrite_enabled, worker_id,
+                    last_heartbeat_at, recovery_count
+                )
+                VALUES (
+                    'run-1', 'project-1', NULL, 'test-model', 4000,
+                    4, 800, 1200, 'QUEUED', 'queued', NULL, NULL, NULL,
+                    NULL, 0, NULL, :now, NULL, NULL, :now, 2,
+                    1, NULL, NULL, 'ollama', '{}', 0, NULL, NULL, 0
+                )
+                """
+            ),
+            {"now": now},
+        )
+
+    command.upgrade(config, "head")
+
+    with engine.connect() as connection:
+        quality_profile = connection.scalar(sa.text("SELECT quality_profile FROM generation_runs WHERE id = 'run-1'"))
+    assert quality_profile == "balanced"
+
+    get_settings.cache_clear()
+    get_session_factory.cache_clear()
+    get_templates.cache_clear()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -286,6 +286,21 @@ def _critique_json(
     )
 
 
+def _nonblocking_revision_critique_json() -> str:
+    payload = json.loads(_critique_json(revision_required=False, side_character_independence_score=8))
+    payload.update(
+        {
+            "warnings": ["The chapter could use more sensory specificity."],
+            "revision_required": True,
+            "focus": ["Sharpen the sensory texture."],
+            "blocking_issues": [],
+            "soft_warnings": ["Sensory texture can be improved."],
+            "repair_scope": "voice_and_texture",
+        }
+    )
+    return json.dumps(payload)
+
+
 def _continuity_json(index: int) -> str:
     return json.dumps(
         {
@@ -1146,6 +1161,135 @@ def test_side_character_score_triggers_targeted_revision(configured_environment)
             and event.payload.get("repair_scope") == "targeted_scene_and_ending"
             for event in refreshed.events
         )
+
+
+def test_strict_quality_profile_triggers_revision_where_balanced_does_not(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    draft = (
+        "Iris slips out of the archive while Tarin resists following her. "
+        "Trigger 1 arrives when the visible actor 1 seals the corridor, leaving only route 1 below them."
+    )
+    revision = (
+        "Iris stopped at the rail while Tarin blocked the route with his shoulder. "
+        "The visible actor 1 sealed the corridor behind them, and Iris handed Tarin the burned key."
+    )
+
+    with session_factory() as session:
+        balanced_project = _create_project(session, requested_chapters=1)
+        balanced_run = create_run(
+            session,
+            balanced_project,
+            RunCreate(project_id=balanced_project.id, model_name="test-model", pause_after_outline=False),
+        )
+        strict_project = _create_project(session, requested_chapters=1)
+        strict_run = create_run(
+            session,
+            strict_project,
+            RunCreate(
+                project_id=strict_project.id,
+                model_name="test-model",
+                pause_after_outline=False,
+                quality_profile="strict",
+            ),
+        )
+        session.commit()
+
+        process_run_safe(
+            session,
+            balanced_run,
+            settings,
+            FakeOllamaClient(
+                [
+                    _story_bible_json(),
+                    _outline_json(1),
+                    _plan_json(1),
+                    draft,
+                    _critique_json(revision_required=False, side_character_independence_score=6),
+                    "Iris accepts the lower route and carries the map underground.",
+                    _continuity_json(1),
+                    _qa_report_json(),
+                ]
+            ),
+        )
+        process_run_safe(
+            session,
+            strict_run,
+            settings,
+            FakeOllamaClient(
+                [
+                    _story_bible_json(),
+                    _outline_json(1),
+                    _plan_json(1),
+                    draft,
+                    _critique_json(revision_required=False, side_character_independence_score=6),
+                    revision,
+                    _critique_json(revision_required=False, side_character_independence_score=8),
+                    "Iris accepts the lower route and carries the map underground.",
+                    _continuity_json(1),
+                    _qa_report_json(),
+                    _developmental_rewrite_json(),
+                ]
+            ),
+        )
+
+        refreshed_balanced = get_run(session, balanced_run.id)
+        refreshed_strict = get_run(session, strict_run.id)
+        assert refreshed_balanced.status == RunStatus.COMPLETED
+        assert refreshed_strict.status == RunStatus.COMPLETED
+        assert refreshed_strict.quality_profile == "strict"
+        assert refreshed_strict.developmental_rewrite_enabled is True
+        assert not any(event.event_type == "chapter_revision_started" for event in refreshed_balanced.events)
+        assert any(
+            event.event_type == "chapter_revision_started"
+            and event.payload.get("repair_scope") == "targeted_scene_and_ending"
+            for event in refreshed_strict.events
+        )
+        assert any(event.event_type == "developmental_rewrite_completed" for event in refreshed_strict.events)
+
+
+def test_draft_quality_profile_defers_non_blocking_revision(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=1)
+        run = create_run(
+            session,
+            project,
+            RunCreate(
+                project_id=project.id,
+                model_name="test-model",
+                pause_after_outline=False,
+                quality_profile="draft",
+            ),
+        )
+        session.commit()
+
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient(
+                [
+                    _story_bible_json(),
+                    _outline_json(1),
+                    _plan_json(1),
+                    "Iris slips out of the archive while Tarin resists following her. Trigger 1 arrives when the visible actor 1 seals the corridor, leaving only route 1 below them.",
+                    _nonblocking_revision_critique_json(),
+                    "Iris accepts the lower route and carries the map underground.",
+                    _continuity_json(1),
+                    _qa_report_json(),
+                ]
+            ),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.COMPLETED
+        assert refreshed.quality_profile == "draft"
+        assert not any(event.event_type == "chapter_revision_started" for event in refreshed.events)
+        qa_notes = refreshed.chapters[0].qa_notes
+        assert qa_notes["revision_required"] is False
+        assert "Draft profile deferred non-blocking revision work" in " ".join(qa_notes["soft_warnings"])
 
 
 def test_canonical_entity_collision_hard_fails_run(configured_environment) -> None:

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -39,7 +39,7 @@ def unreachable_status(default_model: str = "test-model") -> ProviderCapabilitie
     )
 
 
-def seed_project(title: str = "Seed Project") -> str:
+def seed_project(title: str = "Seed Project", *, requested_chapters: int = 4, desired_word_count: int = 4000) -> str:
     session_factory = get_session_factory()
     with session_factory() as session:
         project = create_project(
@@ -47,8 +47,8 @@ def seed_project(title: str = "Seed Project") -> str:
             ProjectCreate(
                 title=title,
                 premise="A seeded premise for route rendering.",
-                desired_word_count=4000,
-                requested_chapters=4,
+                desired_word_count=desired_word_count,
+                requested_chapters=requested_chapters,
                 min_words_per_chapter=800,
                 max_words_per_chapter=1200,
                 preferred_model="test-model",
@@ -63,7 +63,7 @@ def seed_project(title: str = "Seed Project") -> str:
         return project.id
 
 
-def seed_project_and_run() -> tuple[str, str]:
+def seed_project_and_run(*, quality_profile: str = "balanced") -> tuple[str, str]:
     session_factory = get_session_factory()
     with session_factory() as session:
         project = create_project(
@@ -89,6 +89,7 @@ def seed_project_and_run() -> tuple[str, str]:
                 requested_chapters=4,
                 min_words_per_chapter=800,
                 max_words_per_chapter=1200,
+                quality_profile=quality_profile,
             ),
         )
         session.commit()
@@ -273,6 +274,36 @@ def test_project_new_page_renders_story_brief_and_model_picker_hooks(client, mon
     assert "Setup progress" in response.text
     assert "Runs locally on your configured Ollama host." in response.text
     assert "Ollama - Local/private" in response.text
+
+
+def test_project_detail_renders_quality_profile_controls_and_preflight(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
+    project_id = seed_project()
+
+    response = client.get(f"/projects/{project_id}")
+
+    assert response.status_code == 200
+    assert 'data-quality-profile-control' in response.text
+    assert 'name="quality_profile"' in response.text
+    assert 'value="balanced"' in response.text
+    assert "Run preflight" in response.text
+    assert 'data-run-preflight' in response.text
+    assert "Estimated model calls" in response.text
+    assert "23 minimum" in response.text
+    assert "Stage attempt ledger" in response.text
+    assert "Checkpoint resume" in response.text
+
+
+def test_project_detail_preflight_warns_for_64_chapter_runs(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
+    project_id = seed_project(requested_chapters=64, desired_word_count=64000)
+
+    response = client.get(f"/projects/{project_id}")
+
+    assert response.status_code == 200
+    assert "64 chapters will use 8 outline chunks" in response.text
+    assert "High chapter counts make checkpoint resume" in response.text
+    assert "330 minimum" in response.text
 
 
 def test_notice_tone_renders_warning_notice_class(client, monkeypatch) -> None:
@@ -488,6 +519,17 @@ def test_failed_run_detail_surfaces_recovery_guidance(client, monkeypatch) -> No
     assert "Resume from checkpoint" in response.text
     assert "Attempt diagnostics" in response.text
     assert "Run again" in response.text
+
+
+def test_run_detail_shows_quality_profile(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
+    _, run_id = seed_project_and_run(quality_profile="strict")
+
+    response = client.get(f"/runs/{run_id}")
+
+    assert response.status_code == 200
+    assert "Quality profile" in response.text
+    assert "Strict - Most editorial scrutiny" in response.text
 
 
 def test_run_detail_renders_outline_approval_controls(client, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add a `quality_profile` run setting with balanced defaults, draft fast-path behavior, and strict revision/developmental rewrite behavior.
- Add project run preflight context and UI controls for provider/model reachability, outline chunk estimates, call estimates, recovery guardrails, and long-run warnings.
- Surface the selected quality profile on run detail and preserve it through API/UI reruns.

## Tests
- `docker compose exec -T web python -m pytest` (127 passed)
- Docker smoke: `/api/health`, dashboard, projects, provider settings, project detail, and run detail all returned 200 after rebuild/restart.
- Visual check via headless Chrome screenshots for desktop/mobile project detail and mobile run detail.