### PR TITLE
[codex] Add book completion polish workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Novel Generator is a self-hosted, Ollama-first writing studio for long-form fict
 - Background worker process for queued generation runs
 - Ollama provider integration with model discovery and health checks
 - Chapter-level checkpointing and regeneration from any chapter onward
+- Standard developmental planning plus a final chapter edit pass before export
 - Markdown and DOCX artifact export
 - Docker Compose setup for self-hosting
 
@@ -31,6 +32,38 @@ If you want Ollama in the same compose stack, enable the optional profile and po
 ```bash
 docker compose --profile ollama up --build
 ```
+
+## Model Benchmarks
+
+The app can route individual runs to any model reported by Ollama. Benchmark results below are from a controlled local smoke through the app's provider path and attempt ledger; they are useful for routing decisions, not a general leaderboard.
+
+Benchmark environment:
+
+- Date: 2026-05-31
+- Host: Windows 10 10.0.19045 with Docker Desktop 4.74.0 / WSL2, Docker Engine 29.4.3
+- CPU: AMD Ryzen 7 2700X, 8 cores / 16 threads, up to 3.8 GHz
+- RAM: 32 GiB
+- GPU: NVIDIA GeForce RTX 3060, 12 GiB VRAM, driver 610.47
+- App path: Docker Compose `web` container, temporary SQLite database, Ollama at `http://host.docker.internal:11434`
+- Benchmark fixture: 2-chapter balanced project plus a 64-chapter long-context outline review probe
+
+`gemma4:e4b` metadata:
+
+- Official library page: [Ollama gemma4:e4b](https://ollama.com/library/gemma4%3Ae4b)
+- Local Ollama metadata: `gemma4` family, 8.0B parameters, `Q4_K_M`, 131,072 token context
+- Local model size: about 9.6 GB
+
+| Model | Full benchmark time | Structured stages | Prose stages | 64-chapter review | JSON repair usage |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `gemma4:e4b` | 20.2 min | 15.2 min | 4.3 min | 79.8 sec | 1 story-bible repair |
+| `qwen3:14b` | 70.1 min | 54.5 min | 13.2 min | 525.9 sec | 0 |
+| `gpt-oss:20b` | 91.2 min | 65.6 min | 12.6 min | 534.1 sec | 0 |
+
+Current routing guidance:
+
+- Keep the configured default model unchanged until more end-to-end manuscripts are reviewed.
+- `gemma4:e4b` is a strong manual choice for fast draft-profile runs and support stages.
+- Watch story-bible generation closely with `gemma4:e4b`; the benchmark completed successfully, but one story-bible call needed JSON repair before validation.
 
 ## Local Development
 
@@ -61,6 +94,8 @@ On Windows PowerShell, activate the environment with `.venv\Scripts\Activate.ps1
 - `GET /api/runs/{id}`
 - `POST /api/runs/{id}/cancel`
 - `POST /api/runs/{id}/rerun`
+- `POST /api/runs/{id}/resume`
+- `GET /api/runs/{id}/attempts`
 - `GET /api/runs/{id}/events`
 - `GET /api/artifacts/{id}/download`
 
@@ -71,14 +106,17 @@ On Windows PowerShell, activate the environment with `.venv\Scripts\Activate.ps1
 - `src/novel_generator/repositories.py`: database-facing orchestration helpers
 - `alembic/`: migration environment and schema history
 
-The generation pipeline is:
+The generation pipeline is designed to finish a complete book package, even for 32- and 64-chapter runs:
 
 1. Create or reuse an outline.
 2. Plan a chapter.
 3. Draft the chapter.
 4. Summarize it for continuity memory.
 5. Persist progress after each step.
-6. Export Markdown and DOCX artifacts at the end.
+6. Run manuscript QA after the full draft is assembled.
+7. Build a standard developmental rewrite plan and revised-outline report.
+8. Line-edit each saved chapter for polish while preserving approved story state.
+9. Run final manuscript QA, then export Markdown, DOCX, and QA artifacts.
 
 ## Self-Hosting Notes
 
@@ -100,6 +138,6 @@ Additional docs:
 
 ## Current Limits
 
-- Only Ollama is implemented as a model backend in v1.
+- Ollama is the primary local-first backend. OpenAI-compatible routing can be configured separately when explicitly enabled.
 - Runs are processed sequentially by default to avoid oversubscribing local hardware.
 - Chapter regeneration creates a new run from the selected chapter onward instead of mutating history in place.

--- a/alembic/versions/0007_standard_polish_pass.py
+++ b/alembic/versions/0007_standard_polish_pass.py
@@ -1,0 +1,32 @@
+"""standard polish pass defaults"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "0007_standard_polish_pass"
+down_revision = "0006_quality_profiles"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("generation_runs") as batch_op:
+        batch_op.alter_column(
+            "developmental_rewrite_enabled",
+            existing_type=sa.Boolean(),
+            existing_nullable=False,
+            server_default=sa.true(),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("generation_runs") as batch_op:
+        batch_op.alter_column(
+            "developmental_rewrite_enabled",
+            existing_type=sa.Boolean(),
+            existing_nullable=False,
+            server_default=sa.false(),
+        )

--- a/src/novel_generator/models.py
+++ b/src/novel_generator/models.py
@@ -88,7 +88,7 @@ class GenerationRun(Base):
     max_words_per_chapter: Mapped[int] = mapped_column(Integer)
     pipeline_version: Mapped[int] = mapped_column(Integer, default=1)
     pause_after_outline: Mapped[bool] = mapped_column(Boolean, default=True)
-    developmental_rewrite_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
+    developmental_rewrite_enabled: Mapped[bool] = mapped_column(Boolean, default=True)
     quality_profile: Mapped[str] = mapped_column(String(32), default="balanced")
     status: Mapped[RunStatus] = mapped_column(Enum(RunStatus), default=RunStatus.QUEUED)
     current_step: Mapped[str] = mapped_column(String(255), default="queued")

--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -117,9 +117,16 @@ RUN_STAGES = [
     {
         "id": "developmental_rewrite",
         "label": "Developmental rewrite",
-        "description": "Creating a full-manuscript structural rewrite plan when enabled.",
-        "why": "This optional stage turns QA risks into chapter-level keep, merge, cut, bridge, reorder, or rewrite actions.",
+        "description": "Creating the standard full-manuscript structural rewrite plan.",
+        "why": "This stage turns QA risks into chapter-level keep, merge, cut, bridge, reorder, or rewrite actions before the final edit pass.",
         "result": "Rewrite report, revised-outline, and QA comparison artifacts should appear beside the manuscript exports.",
+    },
+    {
+        "id": "chapter_edit",
+        "label": "Final edit",
+        "description": "Polishing saved chapter prose before final QA and export.",
+        "why": "The worker is line-editing each chapter for clarity, rhythm, concrete sensory detail, and cleaner transitions while preserving the story state.",
+        "result": "Chapter text and word counts should update without changing the approved outline or continuity checkpoints.",
     },
     {
         "id": "export",
@@ -183,7 +190,7 @@ QUALITY_PROFILE_DEFS = [
         "value": "balanced",
         "label": "Balanced",
         "summary": "Current behavior",
-        "description": "Use the existing revision thresholds and keep developmental rewrite planning optional.",
+        "description": "Use the existing revision thresholds, standard developmental planning, and the final edit pass.",
     },
     {
         "value": "draft",
@@ -195,7 +202,7 @@ QUALITY_PROFILE_DEFS = [
         "value": "strict",
         "label": "Strict",
         "summary": "Most editorial scrutiny",
-        "description": "Use tighter revision thresholds and include developmental rewrite planning by default.",
+        "description": "Use tighter revision thresholds with standard developmental planning and the final edit pass.",
     },
 ]
 QUALITY_PROFILE_LOOKUP = {item["value"]: item for item in QUALITY_PROFILE_DEFS}
@@ -211,6 +218,7 @@ RUN_STAGE_PROGRESS_ORDER = [
     "chapter_summary",
     "manuscript_qa",
     "developmental_rewrite",
+    "chapter_edit",
     "export",
     "completed",
 ]
@@ -1275,7 +1283,7 @@ def _run_form_values(project: Project, values: dict[str, Any] | None = None) -> 
         "min_words_per_chapter": project.min_words_per_chapter,
         "max_words_per_chapter": project.max_words_per_chapter,
         "pause_after_outline": True,
-        "developmental_rewrite_enabled": False,
+        "developmental_rewrite_enabled": True,
         "quality_profile": "balanced",
         **_task_routing_form_values(project.task_routing),
     }
@@ -1390,7 +1398,7 @@ def _run_preflight_context(
         if requested_chapters <= PREFLIGHT_OUTLINE_CHUNK_THRESHOLD
         else max(1, (requested_chapters + PREFLIGHT_OUTLINE_CHUNK_SIZE - 1) // PREFLIGHT_OUTLINE_CHUNK_SIZE)
     )
-    estimated_model_calls = 1 + outline_chunks + (requested_chapters * 5) + 1
+    estimated_model_calls = 1 + outline_chunks + (requested_chapters * 5) + 1 + requested_chapters + 1
     if developmental_rewrite_enabled:
         estimated_model_calls += 1
 
@@ -1457,6 +1465,8 @@ def _run_preflight_context(
         "status_label": status_label,
         "summary": "Provider, model, outline scale, and recovery guardrails checked before queueing.",
         "warnings": warnings,
+        "outline_chunks": outline_chunks,
+        "estimated_model_calls": estimated_model_calls,
         "rows": [
             {"label": "Provider route", "value": f"{provider_label} / {model_name or '-'}"},
             {"label": "Model reachability", "value": "Reachable" if provider_status and provider_status.reachable else "Unavailable"},
@@ -1469,6 +1479,8 @@ def _run_preflight_context(
         "recovery_features": [
             "Stage attempt ledger",
             "Checkpoint resume",
+            "Standard developmental planning",
+            "Final chapter editing pass",
             f"Stale heartbeat recovery after {max(1, settings.run_stale_after_seconds // 60)} minutes",
         ],
     }
@@ -1882,15 +1894,80 @@ def _chapter_continuity_chips(chapter: Any) -> list[dict[str, str]]:
 
 
 def _chapter_review_cards(run: GenerationRun) -> list[dict[str, Any]]:
-    return [
-        {
-            "chapter": chapter,
-            "status_chips": _chapter_status_chips(chapter),
-            "risk_chips": _chapter_risk_chips(chapter),
-            "continuity_chips": _chapter_continuity_chips(chapter),
+    cards: list[dict[str, Any]] = []
+    for chapter in _sorted_run_chapters(run):
+        risk_chips = _chapter_risk_chips(chapter)
+        cards.append(
+            {
+                "chapter": chapter,
+                "status_chips": _chapter_status_chips(chapter),
+                "risk_chips": risk_chips,
+                "continuity_chips": _chapter_continuity_chips(chapter),
+                "has_risk": any(chip["tone"] in {"risk", "warning"} for chip in risk_chips),
+            }
+        )
+    return cards
+
+
+def _book_completion_context(run: GenerationRun) -> dict[str, Any]:
+    chapters = _sorted_run_chapters(run)
+    requested_chapters = max(1, run.requested_chapters or len(chapters) or 1)
+    outline_count = len(run.outline or [])
+    drafted_count = len([chapter for chapter in chapters if chapter.content])
+    summary_count = len([chapter for chapter in chapters if chapter.summary])
+    continuity_count = len([chapter for chapter in chapters if chapter.continuity_update])
+    qa_count = len([chapter for chapter in chapters if chapter.qa_notes])
+    qa_artifact_count = len([artifact for artifact in run.artifacts if artifact.kind == "qa-report"])
+    manuscript_artifact_count = len([artifact for artifact in run.artifacts if artifact.kind != "qa-report"])
+    final_edit_count = 1 if any(event.event_type == "final_editing_completed" for event in run.events) else 0
+
+    def row(label: str, current: int, target: int, *, required: bool = True) -> dict[str, Any]:
+        is_complete = current >= target if required else current > 0
+        tone = "success" if is_complete else ("warning" if current else "pending")
+        return {
+            "label": label,
+            "current": current,
+            "target": target,
+            "tone": tone,
+            "complete": is_complete,
         }
-        for chapter in _sorted_run_chapters(run)
+
+    rows = [
+        row("Story bible", 1 if run.story_bible else 0, 1),
+        row("Outline chapters", outline_count, requested_chapters),
+        row("Drafted chapters", drafted_count, requested_chapters),
+        row("Chapter summaries", summary_count, requested_chapters),
+        row("Continuity checkpoints", continuity_count, requested_chapters),
+        row("Chapter QA", qa_count, requested_chapters),
+        row("Final edit pass", final_edit_count, 1),
+        row("Manuscript QA report", qa_artifact_count, 1),
+        row("Manuscript exports", manuscript_artifact_count, 1),
     ]
+    required_complete = all(item["complete"] for item in rows)
+    percent = round((sum(min(item["current"], item["target"]) for item in rows) / sum(item["target"] for item in rows)) * 100)
+    if run.status == RunStatus.COMPLETED and required_complete:
+        title = "Complete book package"
+        body = "All requested chapters, continuity checkpoints, QA, final edit, and manuscript exports are present."
+    elif run.status == RunStatus.COMPLETED:
+        title = "Completed with gaps to review"
+        body = "The run reached a terminal state, but one or more book-completion checkpoints is incomplete."
+    elif run.status == RunStatus.FAILED:
+        title = "Recover from the last checkpoint"
+        body = "Use the checklist to see what survived before resuming or regenerating from a chapter."
+    elif run.status == RunStatus.AWAITING_APPROVAL:
+        title = "Outline approval gate"
+        body = "Approve the outline only after the structure looks strong enough to spend the full chapter pass."
+    else:
+        title = "Building the book package"
+        body = "A complete run should finish chapters, checkpoint continuity, run manuscript QA, complete the final edit, run final QA, and export artifacts."
+
+    return {
+        "title": title,
+        "body": body,
+        "rows": rows,
+        "percent": percent,
+        "complete": required_complete,
+    }
 
 
 def _run_attempt_diagnostics(run: GenerationRun) -> list[dict[str, Any]]:
@@ -2986,6 +3063,7 @@ def run_detail(
             "outline_entries": outline_review["entries"],
             "outline_review": outline_review,
             "chapter_review_cards": chapter_review_cards,
+            "book_completion": _book_completion_context(run),
             "editorial_next_step": _run_editorial_next_step_context(run, chapter_review_cards),
             "story_bible": run.story_bible or {},
             "continuity_ledger": run.continuity_ledger or {},

--- a/src/novel_generator/schemas.py
+++ b/src/novel_generator/schemas.py
@@ -929,7 +929,7 @@ class RunCreate(BaseModel):
     min_words_per_chapter: int | None = Field(default=None, ge=1)
     max_words_per_chapter: int | None = Field(default=None, ge=1)
     pause_after_outline: bool = True
-    developmental_rewrite_enabled: bool = False
+    developmental_rewrite_enabled: bool = True
     quality_profile: str = "balanced"
     task_routing: TaskRouting | None = None
     source_run_id: str | None = None

--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -51,6 +51,7 @@ from .provider_errors import ProviderError, ProviderTransportError
 from .prompts import (
     build_chapter_critique_messages,
     build_chapter_draft_messages,
+    build_chapter_edit_messages,
     build_chapter_plan_messages,
     build_chapter_revision_messages,
     build_outline_chunk_messages,
@@ -1754,7 +1755,7 @@ def _run_developmental_rewrite(
     chapters: list,
     qa_report: ManuscriptQaReport,
     client: ProviderManager | OllamaClient,
-) -> tuple[str, str, str]:
+) -> tuple[DevelopmentalRewritePlan, str, str, str]:
     story_bible = _story_bible_from_run(run)
     continuity_ledger = _continuity_ledger_from_run(run)
     provider_name, model_name = _resolve_stage_route(client, run, "developmental_rewrite")
@@ -1798,7 +1799,126 @@ def _run_developmental_rewrite(
         {"message": "Developmental rewrite plan created.", "chapter_action_count": len(plan.chapter_actions)},
     )
     session.commit()
-    return rewrite_markdown, revised_outline_markdown, developmental_qa_markdown
+    return plan, rewrite_markdown, revised_outline_markdown, developmental_qa_markdown
+
+
+def _completed_final_edit_chapters(run: GenerationRun) -> set[int]:
+    completed: set[int] = set()
+    for event in run.events:
+        if event.event_type != "final_chapter_edit_completed":
+            continue
+        chapter_number = event.payload.get("chapter_number")
+        try:
+            completed.add(int(chapter_number))
+        except (TypeError, ValueError):
+            continue
+    return completed
+
+
+def _run_final_editing_pass(
+    session: Session,
+    run: GenerationRun,
+    chapters: list,
+    qa_report: ManuscriptQaReport,
+    developmental_plan: DevelopmentalRewritePlan | None,
+    client: ProviderManager | OllamaClient,
+) -> None:
+    story_bible = _story_bible_from_run(run)
+    continuity_ledger = _continuity_ledger_from_run(run)
+    provider_name, model_name = _resolve_stage_route(client, run, "chapter_revision")
+    edited_chapters = _completed_final_edit_chapters(run)
+    run.current_step = "chapter_edit"
+    run.current_chapter = None
+    record_event(
+        session,
+        run,
+        "final_editing_started",
+        {
+            "message": "Running final chapter editing pass.",
+            "provider_name": provider_name,
+            "model_name": model_name,
+            "chapters": len(chapters),
+        },
+    )
+    session.commit()
+
+    for chapter in chapters:
+        _ensure_not_canceled(session, run)
+        run.current_step = "chapter_edit"
+        run.current_chapter = chapter.chapter_number
+        if chapter.chapter_number in edited_chapters:
+            record_event(
+                session,
+                run,
+                "final_chapter_edit_checkpoint_reused",
+                {
+                    "message": f"Reused saved final edit for chapter {chapter.chapter_number}.",
+                    "chapter_number": chapter.chapter_number,
+                },
+            )
+            session.commit()
+            continue
+
+        try:
+            outline_entry = _outline_entry(run, chapter.chapter_number)
+            edited_content = sanitize_chapter_content(
+                _supervised_provider_chat(
+                    session,
+                    run,
+                    client,
+                    provider_name,
+                    model_name,
+                    build_chapter_edit_messages(
+                        run.project,
+                        chapter,
+                        outline_entry,
+                        story_bible,
+                        continuity_ledger,
+                        qa_report,
+                        developmental_plan,
+                    ),
+                    stage="chapter_edit",
+                    chapter_number=chapter.chapter_number,
+                    metadata={"label": f"chapter {chapter.chapter_number} final edit"},
+                )
+            )
+            if not edited_content.strip():
+                raise RuntimeError(f"Chapter {chapter.chapter_number} final edit was empty.")
+            chapter.content = edited_content
+            chapter.word_count = len((chapter.content or "").split())
+            record_event(
+                session,
+                run,
+                "final_chapter_edit_completed",
+                {
+                    "message": f"Final edit saved for chapter {chapter.chapter_number}.",
+                    "chapter_number": chapter.chapter_number,
+                    "word_count": chapter.word_count,
+                },
+            )
+            session.commit()
+        except Exception as exc:
+            chapter.word_count = len((chapter.content or "").split())
+            record_event(
+                session,
+                run,
+                "final_chapter_edit_fallback",
+                {
+                    "message": f"Final edit failed for chapter {chapter.chapter_number}; kept the existing chapter prose.",
+                    "chapter_number": chapter.chapter_number,
+                    "error": str(exc),
+                },
+            )
+            session.commit()
+
+    run.current_chapter = None
+    record_event(
+        session,
+        run,
+        "final_editing_completed",
+        {"message": "Final chapter editing pass completed.", "chapters": len(chapters)},
+    )
+    session.commit()
 
 
 def process_run(session: Session, run: GenerationRun, settings: Settings, client: ProviderManager | OllamaClient) -> None:
@@ -1851,17 +1971,22 @@ def process_run(session: Session, run: GenerationRun, settings: Settings, client
         )
 
     qa_report, qa_markdown = _run_manuscript_qa(session, run, completed_chapters, client)
+    developmental_plan: DevelopmentalRewritePlan | None = None
     rewrite_markdown = None
     revised_outline_markdown = None
     developmental_qa_markdown = None
     if run.developmental_rewrite_enabled:
-        rewrite_markdown, revised_outline_markdown, developmental_qa_markdown = _run_developmental_rewrite(
+        developmental_plan, rewrite_markdown, revised_outline_markdown, developmental_qa_markdown = _run_developmental_rewrite(
             session,
             run,
             completed_chapters,
             qa_report,
             client,
         )
+
+    _run_final_editing_pass(session, run, completed_chapters, qa_report, developmental_plan, client)
+    completed_chapters = _require_requested_chapters(session, run)
+    qa_report, qa_markdown = _run_manuscript_qa(session, run, completed_chapters, client)
 
     run.current_step = "export"
     record_event(session, run, "artifact_export_started", {"message": "Rendering manuscript artifacts."})

--- a/src/novel_generator/services/prompts.py
+++ b/src/novel_generator/services/prompts.py
@@ -1054,6 +1054,97 @@ def build_developmental_rewrite_messages(
     ]
 
 
+def _developmental_action_for_chapter(plan: DevelopmentalRewritePlan | dict[str, Any] | None, chapter_number: int) -> dict[str, Any]:
+    if plan is None:
+        return {}
+    payload = plan if isinstance(plan, dict) else plan.model_dump()
+    for action in payload.get("chapter_actions", []) or []:
+        chapter_numbers = action.get("chapter_numbers", []) if isinstance(action, dict) else []
+        if chapter_number in [int(number) for number in chapter_numbers if str(number).isdigit()]:
+            return action
+    return {}
+
+
+def _qa_editing_context(qa_report: ManuscriptQaReport) -> dict[str, Any]:
+    payload = qa_report.model_dump()
+    keys = [
+        "overall_verdict",
+        "warnings",
+        "continuity_risks",
+        "repetition_risks",
+        "ending_coherence_notes",
+        "lint_findings",
+        "chapter_ending_quality_notes",
+        "easy_win_warnings",
+        "proper_noun_continuity_findings",
+        "side_character_agency_notes",
+        "atmospheric_repetition_findings",
+        "emotional_pacing_notes",
+        "ideology_consistency_findings",
+        "civilian_texture_findings",
+        "technical_escalation_fatigue_findings",
+        "crisis_loop_findings",
+        "scene_mode_distribution_notes",
+        "story_turn_quality_notes",
+        "genre_contract_notes",
+    ]
+    return {key: payload.get(key) for key in keys if payload.get(key)}
+
+
+def build_chapter_edit_messages(
+    project: Project,
+    chapter: ChapterDraft,
+    outline_entry: StructuredOutlineEntry | dict[str, Any],
+    story_bible: StoryBible | dict[str, Any],
+    continuity_ledger: ContinuityLedger | dict[str, Any],
+    qa_report: ManuscriptQaReport,
+    developmental_plan: DevelopmentalRewritePlan | dict[str, Any] | None = None,
+) -> list[dict[str, str]]:
+    entry = outline_entry if isinstance(outline_entry, dict) else outline_entry.model_dump()
+    bible = story_bible if isinstance(story_bible, dict) else story_bible.model_dump()
+    ledger = continuity_ledger if isinstance(continuity_ledger, dict) else continuity_ledger.model_dump()
+    profile = _story_bible_genre_profile(bible)
+    style_profile = bible.get("style_profile") or {}
+    continuity_payload = _chapter_continuity_payload(chapter)
+    developmental_action = _developmental_action_for_chapter(developmental_plan, chapter.chapter_number)
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a senior line editor and continuity-safe copy editor for fiction. "
+                "Return polished chapter prose only, with no heading, notes, JSON, or markdown fences."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Final-edit chapter {chapter.chapter_number} of '{project.title}'.\n\n"
+                f"Story bible:\n{json.dumps(bible, indent=2)}\n\n"
+                f"Selected genre profile:\n{_genre_profile_block(profile)}\n\n"
+                f"Prose style profile:\n{json.dumps(style_profile, indent=2)}\n\n"
+                f"Chapter outline:\n{json.dumps(entry, indent=2)}\n\n"
+                f"Chapter continuity state:\n{json.dumps(continuity_payload, indent=2)}\n\n"
+                f"Current continuity ledger:\n{json.dumps(ledger, indent=2)}\n\n"
+                f"Manuscript QA editing context:\n{json.dumps(_qa_editing_context(qa_report), indent=2)}\n\n"
+                f"Developmental action for this chapter:\n{json.dumps(developmental_action, indent=2)}\n\n"
+                f"Current chapter prose:\n{chapter.content or ''}\n\n"
+                "Final editing instructions:\n"
+                "- preserve the same plot events, order of events, POV, named entities, relationship state, and continuity outcome\n"
+                "- do not add a new scene, new twist, new system rule, new character, chapter heading, author note, or outline summary\n"
+                "- polish sentence rhythm, paragraph flow, transitions, sensory specificity, and dialogue subtext\n"
+                "- remove repeated phrasing, filler explanation, and meta/outlining language such as 'the next problem', 'the chapter ends', 'pushing the story forward', or 'sets up'\n"
+                "- replace vague emotional labels with concrete gesture, image, choice, or fallout where the existing scene supports it\n"
+                "- make technical stakes legible through visible human cost and on-page consequence\n"
+                "- sharpen side-character agency without changing the continuity outcome\n"
+                "- keep the ending concrete: a visible action, irreversible choice, reveal, reversal, or state change, not a thesis about what comes next\n"
+                "- honor the style profile and selected genre profile without imitating any protected style reference\n"
+                "- keep roughly the same length unless trimming improves repetition or clarity\n\n"
+                "Return final edited chapter prose only."
+            ),
+        },
+    ]
+
+
 def build_json_repair_messages(raw_text: str, label: str, issue: str | None = None) -> list[dict[str, str]]:
     issue_text = f"\nParser or schema error:\n{issue}\n\n" if issue else "\n"
     return [

--- a/src/novel_generator/static/style.css
+++ b/src/novel_generator/static/style.css
@@ -304,6 +304,73 @@ textarea:focus-visible {
   padding: 1.4rem;
 }
 
+.project-premise-preview,
+.project-card .chapter-copy,
+.run-row-event {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.project-premise-preview {
+  -webkit-line-clamp: 4;
+}
+
+.project-card .chapter-copy {
+  -webkit-line-clamp: 5;
+}
+
+.run-row-event {
+  -webkit-line-clamp: 3;
+}
+
+.project-brief-details {
+  margin: 0.85rem 0;
+}
+
+.project-brief-body {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.project-brief-body p {
+  margin: 0;
+  white-space: pre-wrap;
+}
+
+.project-command-bar {
+  position: sticky;
+  top: 0.75rem;
+  z-index: 4;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.85rem;
+  align-items: center;
+  padding: 0.82rem 0.9rem;
+  border: 1px solid rgba(23, 106, 90, 0.22);
+  border-radius: var(--radius);
+  background: rgba(255, 252, 246, 0.96);
+  box-shadow: 0 14px 30px rgba(45, 37, 28, 0.12);
+}
+
+.project-command-summary {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.project-command-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.55rem;
+  min-width: 0;
+}
+
+.project-command-actions .button {
+  padding: 0.62rem 0.82rem;
+}
+
 .hero-card h1,
 .panel h1,
 .panel h2,
@@ -702,6 +769,26 @@ dd {
 
 .outline-card.is-focused-outline {
   box-shadow: 0 0 0 3px rgba(23, 106, 90, 0.2), var(--shadow);
+}
+
+.outline-review-dock {
+  position: sticky;
+  bottom: 0.85rem;
+  z-index: 5;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.85rem;
+  align-items: center;
+  margin-top: 1rem;
+  padding: 0.82rem;
+  border: 1px solid rgba(23, 106, 90, 0.24);
+  border-radius: var(--radius);
+  background: rgba(255, 252, 246, 0.96);
+  box-shadow: 0 18px 38px rgba(45, 37, 28, 0.16);
+}
+
+.outline-review-dock .row-actions {
+  justify-content: flex-end;
 }
 
 .outline-warning-reasons {
@@ -1335,9 +1422,79 @@ dd {
   box-shadow: 0 20px 45px rgba(23, 106, 90, 0.12);
 }
 
+.chapter-card.is-focused-chapter {
+  box-shadow: 0 0 0 3px rgba(23, 106, 90, 0.18), var(--shadow);
+}
+
 .chapter-card p,
 .chapter-card details {
   margin: 0;
+}
+
+.chapter-review-toolbar {
+  display: grid;
+  gap: 0.85rem;
+  margin-bottom: 0.9rem;
+  padding: 0.85rem;
+  border: 1px solid rgba(217, 207, 192, 0.95);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.chapter-review-controls {
+  display: grid;
+  grid-template-columns: minmax(9rem, 0.8fr) minmax(7rem, 0.5fr) repeat(2, auto) auto;
+  gap: 0.55rem;
+  align-items: end;
+}
+
+.chapter-review-controls button {
+  min-height: 2.55rem;
+}
+
+.chapter-anchor-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  max-height: 8.2rem;
+  overflow: auto;
+  padding-right: 0.15rem;
+}
+
+.chapter-anchor {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.2rem;
+  height: 2.2rem;
+  border: 1px solid rgba(212, 221, 215, 0.95);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--accent-strong);
+  font-weight: 800;
+  line-height: 1;
+}
+
+.chapter-anchor:hover,
+.chapter-anchor:focus-visible {
+  border-color: rgba(23, 106, 90, 0.38);
+  background: rgba(23, 106, 90, 0.1);
+}
+
+.chapter-anchor.has-risk {
+  border-color: rgba(166, 66, 51, 0.28);
+  color: var(--danger);
+  background: rgba(166, 66, 51, 0.07);
+}
+
+.chapter-anchor.is-current {
+  border-color: rgba(23, 106, 90, 0.48);
+  background: rgba(23, 106, 90, 0.14);
+  box-shadow: inset 0 0 0 1px rgba(23, 106, 90, 0.18);
+}
+
+.chapter-anchor.is-muted {
+  opacity: 0.32;
 }
 
 .chapter-topline {
@@ -1727,6 +1884,48 @@ code {
   padding: 0.72rem 0.85rem;
 }
 
+.length-preset-shell {
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.72rem 0.78rem;
+  border: 1px solid rgba(212, 221, 215, 0.95);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.5);
+}
+
+.length-preset-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.length-preset-row button {
+  width: 100%;
+  min-height: 2.45rem;
+  padding-inline: 0.55rem;
+}
+
+.run-estimate-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.run-estimate-strip > div {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+  padding: 0.68rem 0.72rem;
+  border: 1px solid rgba(217, 207, 192, 0.9);
+  border-radius: var(--radius);
+  background: rgba(247, 243, 235, 0.72);
+}
+
+.run-estimate-strip strong {
+  overflow-wrap: anywhere;
+  line-height: 1.25;
+}
+
 .quality-profile-section {
   gap: 0.85rem;
 }
@@ -1859,6 +2058,96 @@ code {
   line-height: 1.22;
 }
 
+.run-progress-rails {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+}
+
+.progress-rail {
+  display: grid;
+  gap: 0.45rem;
+  min-width: 0;
+  padding: 0.72rem 0.78rem;
+  border: 1px solid rgba(212, 221, 215, 0.95);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.progress-rail-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: baseline;
+  flex-wrap: wrap;
+}
+
+.progress-track {
+  width: 100%;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgba(28, 31, 38, 0.08);
+  overflow: hidden;
+}
+
+.progress-track span {
+  display: block;
+  height: 100%;
+  max-width: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, rgba(23, 106, 90, 0.7), rgba(23, 106, 90, 0.98));
+}
+
+.book-completion-panel {
+  display: grid;
+  gap: 0.85rem;
+  margin-top: 1rem;
+  padding: 0.95rem;
+  border: 1px solid rgba(23, 106, 90, 0.2);
+  border-radius: var(--radius);
+  background: rgba(23, 106, 90, 0.06);
+}
+
+.book-completion-score {
+  display: grid;
+  justify-items: end;
+  align-content: center;
+  gap: 0.1rem;
+  min-width: 7rem;
+}
+
+.book-completion-score strong {
+  font-size: clamp(1.55rem, 4vw, 2.25rem);
+  line-height: 1;
+  color: var(--accent-strong);
+}
+
+.book-completion-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+  gap: 0.55rem;
+}
+
+.book-completion-item {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+  padding: 0.62rem 0.68rem;
+  border: 1px solid rgba(212, 221, 215, 0.95);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.62);
+}
+
+.book-completion-success {
+  border-color: rgba(18, 107, 63, 0.22);
+  background: rgba(18, 107, 63, 0.07);
+}
+
+.book-completion-warning {
+  border-color: rgba(184, 126, 24, 0.28);
+  background: rgba(184, 126, 24, 0.08);
+}
+
 .run-meta-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
@@ -1918,9 +2207,12 @@ code {
   .run-overview,
   .metric-grid,
   .run-setup-grid,
+  .project-command-bar,
   .run-status-strip,
+  .run-progress-rails,
   .run-meta-grid,
   .quality-profile-grid,
+  .run-estimate-strip,
   .preflight-grid,
   .management-grid,
   .quick-action-grid,
@@ -1936,6 +2228,10 @@ code {
 
   .shell-header {
     justify-items: start;
+  }
+
+  .project-command-actions {
+    justify-content: flex-start;
   }
 
   .project-card,
@@ -1981,12 +2277,18 @@ code {
 
   .outline-summary-strip,
   .outline-distribution-grid,
-  .outline-filter-bar {
+  .outline-filter-bar,
+  .outline-review-dock,
+  .chapter-review-controls {
     grid-template-columns: 1fr;
   }
 
   .outline-filter-actions {
     align-items: stretch;
+  }
+
+  .outline-review-dock .row-actions {
+    justify-content: flex-start;
   }
 
   .editorial-next-grid,
@@ -2026,15 +2328,46 @@ code {
   }
 
   .project-card dl,
+  .project-command-bar,
   .stats-grid,
   .story-bible-grid,
   .artifact-card,
   .run-stepper,
   .metric-grid,
   .run-status-strip,
+  .run-progress-rails,
+  .run-estimate-strip,
+  .length-preset-row,
   .run-setup-grid,
   .quick-action-grid {
     grid-template-columns: 1fr;
+  }
+
+  .book-completion-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .book-completion-score {
+    justify-items: start;
+  }
+
+  .project-command-bar {
+    position: static;
+  }
+
+  .project-command-actions,
+  .project-command-actions .button {
+    width: 100%;
+  }
+
+  .project-command-actions {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .chapter-review-toolbar,
+  .outline-review-dock {
+    position: static;
   }
 
   .model-chip-list {

--- a/src/novel_generator/static/ui.js
+++ b/src/novel_generator/static/ui.js
@@ -1,9 +1,11 @@
 document.addEventListener("DOMContentLoaded", () => {
   setupConfirmActions(document);
   setupModelPickers(document);
+  setupRunLengthControls(document);
   setupRunModeNotes(document);
   setupQualityProfileControls(document);
   setupOutlineReview(document);
+  setupChapterNavigator(document);
   setupReviewSections(document);
   setupProviderConsole();
   setupRunDetail();
@@ -71,6 +73,86 @@ function bindModelChoice(choice, syncChoices) {
     input.focus();
     input.scrollIntoView({ behavior: "smooth", block: "nearest" });
     syncChoices(targetId);
+  });
+}
+
+function setupRunLengthControls(root) {
+  const forms = Array.from(root.querySelectorAll("[data-run-queue-form]"));
+  forms.forEach((form) => {
+    if (form.dataset.runLengthBound === "true") {
+      return;
+    }
+    form.dataset.runLengthBound = "true";
+
+    const chapterInput = form.querySelector("[data-run-chapter-count]");
+    const targetInput = form.querySelector("[data-run-target-words]");
+    const minInput = form.querySelector("[data-run-min-words]");
+    const maxInput = form.querySelector("[data-run-max-words]");
+    const outlineNode = form.querySelector("[data-run-estimate-outline]");
+    const callsNode = form.querySelector("[data-run-estimate-calls]");
+    const averageNode = form.querySelector("[data-run-estimate-average]");
+    const presetButtons = Array.from(form.querySelectorAll("[data-run-length-preset]"));
+    const outlineThreshold = 32;
+    const outlineChunkSize = 8;
+
+    const readInt = (node, fallback) => {
+      const value = Number.parseInt(node?.value || "", 10);
+      return Number.isFinite(value) && value > 0 ? value : fallback;
+    };
+
+    const outlineChunksFor = (chapters) => {
+      if (chapters <= outlineThreshold) {
+        return 1;
+      }
+      return Math.max(1, Math.ceil(chapters / outlineChunkSize));
+    };
+
+    const sync = () => {
+      const chapters = readInt(chapterInput, 1);
+      const targetWords = readInt(targetInput, 0);
+      const minWords = readInt(minInput, 0);
+      const maxWords = readInt(maxInput, minWords || 0);
+      const outlineChunks = outlineChunksFor(chapters);
+      const developmentalRewrite = form.querySelector("[data-developmental-rewrite-toggle]")?.checked ? 1 : 0;
+      const finalEditCalls = chapters + 1;
+      const minimumCalls = 1 + outlineChunks + chapters * 5 + 1 + developmentalRewrite + finalEditCalls;
+      const average = chapters > 0 && targetWords > 0 ? Math.round(targetWords / chapters) : 0;
+
+      if (outlineNode) {
+        outlineNode.textContent = String(outlineChunks);
+      }
+      if (callsNode) {
+        callsNode.textContent = `${minimumCalls} minimum`;
+      }
+      if (averageNode) {
+        const rangeNote = minWords && maxWords ? ` (${minWords}-${maxWords})` : "";
+        averageNode.textContent = average ? `${average} words${rangeNote}` : "--";
+      }
+    };
+
+    presetButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const chapters = Number.parseInt(button.dataset.runLengthPreset || "", 10);
+        if (!Number.isFinite(chapters) || !chapterInput) {
+          return;
+        }
+        chapterInput.value = String(chapters);
+        const minWords = readInt(minInput, 0);
+        const currentTarget = readInt(targetInput, 0);
+        const minimumTarget = minWords ? chapters * minWords : 0;
+        if (targetInput && minimumTarget && currentTarget < minimumTarget) {
+          targetInput.value = String(minimumTarget);
+        }
+        chapterInput.dispatchEvent(new Event("input", { bubbles: true }));
+        sync();
+      });
+    });
+
+    [chapterInput, targetInput, minInput, maxInput, form.querySelector("[data-developmental-rewrite-toggle]")].forEach((node) => {
+      node?.addEventListener("input", sync);
+      node?.addEventListener("change", sync);
+    });
+    sync();
   });
 }
 
@@ -235,6 +317,104 @@ function setupOutlineReview(root) {
       syncFilters();
     });
     syncFilters();
+  });
+}
+
+function setupChapterNavigator(root) {
+  const toolbars = Array.from(root.querySelectorAll("[data-chapter-review-toolbar]"));
+  toolbars.forEach((toolbar) => {
+    if (toolbar.dataset.chapterNavigatorBound === "true") {
+      return;
+    }
+    toolbar.dataset.chapterNavigatorBound = "true";
+
+    const section = toolbar.closest("section");
+    const cards = Array.from(section?.querySelectorAll("[data-chapter-card]") || []);
+    const anchors = Array.from(toolbar.querySelectorAll("[data-chapter-anchor]"));
+    const statusFilter = toolbar.querySelector("[data-chapter-status-filter]");
+    const jumpInput = toolbar.querySelector("[data-chapter-jump-input]");
+    const jumpButton = toolbar.querySelector("[data-chapter-jump]");
+    const clearButton = toolbar.querySelector("[data-chapter-clear]");
+    const visibleCount = toolbar.querySelector("[data-chapter-visible-count]");
+    const emptyState = toolbar.querySelector("[data-chapter-empty]");
+
+    const setHidden = (node, hidden) => {
+      if (node) {
+        node.classList.toggle("is-hidden", hidden);
+      }
+    };
+    const numberValue = (node, fallback) => {
+      const value = Number(node?.value);
+      return Number.isFinite(value) ? value : fallback;
+    };
+
+    const sync = () => {
+      const filter = statusFilter?.value || "";
+      let shown = 0;
+
+      cards.forEach((card) => {
+        let visible = true;
+        const isCurrent = card.dataset.chapterCurrent === "true";
+        const isComplete = card.dataset.chapterStatus === "completed";
+        const hasRisk = card.dataset.chapterRisk === "true";
+        const hasContent = card.dataset.chapterHasContent === "true";
+
+        if (filter === "current") {
+          visible = isCurrent;
+        } else if (filter === "complete") {
+          visible = isComplete;
+        } else if (filter === "risk") {
+          visible = hasRisk;
+        } else if (filter === "pending") {
+          visible = !hasContent;
+        }
+
+        setHidden(card, !visible);
+        if (visible) {
+          shown += 1;
+        }
+      });
+
+      anchors.forEach((anchor) => {
+        const chapter = Number(anchor.dataset.chapterAnchor || 0);
+        const card = cards.find((candidate) => Number(candidate.dataset.chapterNumber || 0) === chapter);
+        anchor.classList.toggle("is-muted", Boolean(card?.classList.contains("is-hidden")));
+      });
+
+      if (visibleCount) {
+        visibleCount.textContent = `${shown} chapter${shown === 1 ? "" : "s"} visible`;
+      }
+      setHidden(emptyState, shown > 0);
+    };
+
+    const jump = () => {
+      const chapter = numberValue(jumpInput, 1);
+      const target = cards.find((card) => Number(card.dataset.chapterNumber || 0) === chapter);
+      if (!target) {
+        return;
+      }
+      target.classList.remove("is-hidden");
+      target.scrollIntoView({ behavior: "smooth", block: "start" });
+      target.classList.add("is-focused-chapter");
+      window.history.replaceState(null, "", `#${target.id}`);
+      window.setTimeout(() => target.classList.remove("is-focused-chapter"), 1600);
+    };
+
+    statusFilter?.addEventListener("change", sync);
+    jumpButton?.addEventListener("click", jump);
+    jumpInput?.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        jump();
+      }
+    });
+    clearButton?.addEventListener("click", () => {
+      if (statusFilter) {
+        statusFilter.value = "";
+      }
+      sync();
+    });
+    sync();
   });
 }
 
@@ -476,8 +656,11 @@ function setupRunDetail() {
   const runHealthFallbackNode = runDetail.querySelector("[data-run-health-fallbacks]");
   const elapsedNode = runDetail.querySelector("[data-run-elapsed]");
   const completedChapterNode = runDetail.querySelector("[data-run-completed-chapters]");
+  const chapterProgressLabelNodes = Array.from(runDetail.querySelectorAll("[data-run-chapter-progress-label]"));
+  const chapterProgressBarNodes = Array.from(runDetail.querySelectorAll("[data-run-chapter-progress-bar]"));
   const wordProgressNode = runDetail.querySelector("[data-run-word-progress]");
-  const wordProgressLabelNode = runDetail.querySelector("[data-run-word-progress-label]");
+  const wordProgressLabelNodes = Array.from(runDetail.querySelectorAll("[data-run-word-progress-label]"));
+  const wordProgressBarNodes = Array.from(runDetail.querySelectorAll("[data-run-word-progress-bar]"));
   const artifactCountNode = runDetail.querySelector("[data-run-artifact-count]");
   const eventCountNode = runDetail.querySelector("[data-run-event-count]");
   const stepper = runDetail.querySelector("[data-run-stepper]");
@@ -1197,17 +1380,28 @@ function setupRunDetail() {
     const completedChapters = completedChapterCount(run);
     const words = totalWords(run);
     const targetWords = Number(run.target_word_count || 0);
+    const requestedChapters = Number(run.requested_chapters || runDetail.dataset.runRequestedChapters || 0);
     const progressPercent = targetWords > 0 ? Math.min(100, Math.round((words / targetWords) * 100)) : 0;
+    const chapterProgressPercent = requestedChapters > 0 ? Math.min(100, Math.round((completedChapters / requestedChapters) * 100)) : 0;
 
     if (completedChapterNode) {
       completedChapterNode.textContent = String(completedChapters);
     }
+    chapterProgressLabelNodes.forEach((node) => {
+      node.textContent = `${completedChapters} / ${requestedChapters || "-"}`;
+    });
+    chapterProgressBarNodes.forEach((node) => {
+      node.style.width = `${chapterProgressPercent}%`;
+    });
     if (wordProgressNode) {
       wordProgressNode.textContent = String(words);
     }
-    if (wordProgressLabelNode) {
-      wordProgressLabelNode.textContent = `${progressPercent}%`;
-    }
+    wordProgressLabelNodes.forEach((node) => {
+      node.textContent = `${progressPercent}%`;
+    });
+    wordProgressBarNodes.forEach((node) => {
+      node.style.width = `${progressPercent}%`;
+    });
     if (artifactCountNode) {
       artifactCountNode.textContent = String(Array.from(run.artifacts || []).length);
     }

--- a/src/novel_generator/templates/project_detail.html
+++ b/src/novel_generator/templates/project_detail.html
@@ -8,17 +8,24 @@
     <div class="page-header-copy">
       <p class="eyebrow">Project</p>
       <h1>{{ project.title }}</h1>
-      <p class="hero-copy">{{ project.premise }}</p>
+      <p class="hero-copy project-premise-preview">{{ project.premise }}</p>
     </div>
     <div class="hero-actions">
+      <a class="button" href="#queue-run">Queue full draft</a>
       <a class="button secondary" href="/projects">Back to projects</a>
       <a class="button secondary" href="/settings/provider">Provider settings</a>
     </div>
   </div>
 
-  {% if project.notes %}
-    <p class="muted">{{ project.notes }}</p>
-  {% endif %}
+  <details class="compact-details project-brief-details">
+    <summary>Full project brief</summary>
+    <div class="project-brief-body">
+      <p>{{ project.premise }}</p>
+      {% if project.notes %}
+        <p>{{ project.notes }}</p>
+      {% endif %}
+    </div>
+  </details>
 
   <dl class="stats-grid">
     <div><dt>Target words</dt><dd>{{ project.desired_word_count }}</dd></div>
@@ -46,7 +53,21 @@
   </section>
 {% endif %}
 
-<section class="panel">
+<section class="project-command-bar" aria-label="Project command shortcuts">
+  <div class="project-command-summary">
+    <span class="detail-label">Complete book target</span>
+    <strong>{{ project.requested_chapters }} chapters / {{ project.desired_word_count }} words</strong>
+    <span class="field-note long-value">{{ project.preferred_provider_name }} / {{ project.preferred_model }}</span>
+  </div>
+  <div class="project-command-actions">
+    <a class="button" href="#queue-run">Queue full draft</a>
+    <a class="button secondary" href="#run-history">Run history</a>
+    <a class="button secondary" href="#canon">Canon</a>
+    <a class="button secondary" href="#edit-project">Edit defaults</a>
+  </div>
+</section>
+
+<section class="panel" id="edit-project">
   <details class="editor-shell" {% if open_edit_form %}open{% endif %}>
     <summary>Edit project defaults</summary>
 
@@ -378,7 +399,7 @@
   {% endif %}
 </section>
 
-<section class="grid two-up form-layout">
+<section class="grid two-up form-layout" id="queue-run">
   <article class="panel">
     <div class="section-header">
       <div class="section-header-copy">
@@ -391,7 +412,7 @@
       <p class="error-text">{{ run_errors.__all__ }}</p>
     {% endif %}
 
-    <form method="post" action="/projects/{{ project.id }}/runs/new" class="stack-form run-queue-form">
+    <form method="post" action="/projects/{{ project.id }}/runs/new" class="stack-form run-queue-form" data-run-queue-form>
       <div class="run-setup-grid">
         <div class="form-section run-cardlet">
           <div class="section-header-copy">
@@ -474,35 +495,59 @@
           <div class="grid compact run-shape-grid">
             <label>
               Total words
-              <input class="{{ 'input-invalid' if run_errors.target_word_count }}" type="number" name="target_word_count" value="{{ run_values.target_word_count }}" min="1000">
+              <input data-run-target-words class="{{ 'input-invalid' if run_errors.target_word_count }}" type="number" name="target_word_count" value="{{ run_values.target_word_count }}" min="1000">
             </label>
             <label>
               Chapters
-              <input class="{{ 'input-invalid' if run_errors.requested_chapters }}" type="number" name="requested_chapters" value="{{ run_values.requested_chapters }}" min="1">
+              <input data-run-chapter-count class="{{ 'input-invalid' if run_errors.requested_chapters }}" type="number" name="requested_chapters" value="{{ run_values.requested_chapters }}" min="1">
             </label>
           </div>
           {% if run_errors.target_word_count %}<p class="field-error">{{ run_errors.target_word_count }}</p>{% endif %}
           {% if run_errors.requested_chapters %}<p class="field-error">{{ run_errors.requested_chapters }}</p>{% endif %}
 
+          <div class="length-preset-shell" aria-label="Chapter count presets">
+            <span class="detail-label">Book length</span>
+            <div class="length-preset-row">
+              <button class="secondary" type="button" data-run-length-preset="12">12 chapters</button>
+              <button class="secondary" type="button" data-run-length-preset="32">32 chapters</button>
+              <button class="secondary" type="button" data-run-length-preset="64">64 chapters</button>
+            </div>
+          </div>
+
           <div class="grid compact">
             <label>
               Min words per chapter
-              <input class="{{ 'input-invalid' if run_errors.min_words_per_chapter }}" type="number" name="min_words_per_chapter" value="{{ run_values.min_words_per_chapter }}" min="100">
+              <input data-run-min-words class="{{ 'input-invalid' if run_errors.min_words_per_chapter }}" type="number" name="min_words_per_chapter" value="{{ run_values.min_words_per_chapter }}" min="100">
             </label>
             <label>
               Max words per chapter
-              <input class="{{ 'input-invalid' if run_errors.max_words_per_chapter }}" type="number" name="max_words_per_chapter" value="{{ run_values.max_words_per_chapter }}" min="100">
+              <input data-run-max-words class="{{ 'input-invalid' if run_errors.max_words_per_chapter }}" type="number" name="max_words_per_chapter" value="{{ run_values.max_words_per_chapter }}" min="100">
             </label>
           </div>
           {% if run_errors.min_words_per_chapter %}<p class="field-error">{{ run_errors.min_words_per_chapter }}</p>{% endif %}
           {% if run_errors.max_words_per_chapter %}<p class="field-error">{{ run_errors.max_words_per_chapter }}</p>{% endif %}
+
+          <div class="run-estimate-strip" data-run-estimate>
+            <div>
+              <span class="detail-label">Outline chunks</span>
+              <strong data-run-estimate-outline>{{ run_preflight.outline_chunks }}</strong>
+            </div>
+            <div>
+              <span class="detail-label">Minimum calls</span>
+              <strong data-run-estimate-calls>{{ run_preflight.estimated_model_calls }} minimum</strong>
+            </div>
+            <div>
+              <span class="detail-label">Avg chapter target</span>
+              <strong data-run-estimate-average>--</strong>
+            </div>
+          </div>
         </div>
       </div>
 
       <div class="form-section run-cardlet quality-profile-section" data-quality-profile-control>
         <div class="section-header-copy">
           <h3>Quality profile</h3>
-          <p>Choose how aggressively this run should spend time on editorial repair passes.</p>
+          <p>Choose how aggressively this run should spend time on chapter repairs before the standard developmental and final edit passes.</p>
         </div>
         <div class="quality-profile-grid">
           {% for option in quality_profile_options %}
@@ -540,21 +585,21 @@
       <label class="toggle-card run-mode-card">
         <span class="toggle-input">
           <input data-developmental-rewrite-toggle type="checkbox" name="developmental_rewrite_enabled" value="1" {% if run_values.developmental_rewrite_enabled or run_values.quality_profile == "strict" %}checked{% endif %}>
-          <strong>Run developmental rewrite planning</strong>
+          <strong>Include developmental rewrite planning</strong>
         </span>
-        <span class="field-note">After manuscript QA, produce a structural rewrite report, revised outline, and QA comparison for merge, cut, bridge, reorder, or rewrite decisions.</span>
+        <span class="field-note">Standard for polished book runs. After manuscript QA, produce a structural rewrite report, revised outline, and QA comparison before the final chapter edit pass.</span>
       </label>
 
       <div
         class="inline-note inline-note-success run-mode-note"
         data-run-mode-note
-        data-pause-message="Build the story bible and outline, wait for approval, then draft chapters, run editorial QA, optional developmental rewrite planning, and export artifacts."
-        data-straight-message="Move straight from story bible and outline generation into chapter drafting, editorial QA, optional developmental rewrite planning, and export."
+        data-pause-message="Build the story bible and outline, wait for approval, then draft chapters, run editorial QA, developmental planning, final chapter editing, final QA, and export artifacts."
+        data-straight-message="Move straight from story bible and outline generation into chapter drafting, editorial QA, developmental planning, final chapter editing, final QA, and export."
       >
         {% if run_values.pause_after_outline %}
-          Build the story bible and outline, wait for approval, then draft chapters, run editorial QA, optional developmental rewrite planning, and export artifacts.
+          Build the story bible and outline, wait for approval, then draft chapters, run editorial QA, developmental planning, final chapter editing, final QA, and export artifacts.
         {% else %}
-          Move straight from story bible and outline generation into chapter drafting, editorial QA, optional developmental rewrite planning, and export.
+          Move straight from story bible and outline generation into chapter drafting, editorial QA, developmental planning, final chapter editing, final QA, and export.
         {% endif %}
       </div>
 
@@ -641,7 +686,14 @@
           <span class="run-flow-number">5</span>
           <div>
             <strong>Plan a developmental rewrite</strong>
-            <p class="field-note">Optional full-manuscript planning converts QA risks into structural actions, a revised outline, and a before/after QA comparison.</p>
+            <p class="field-note">Standard full-manuscript planning converts QA risks into structural actions, a revised outline, and a before/after QA comparison.</p>
+          </div>
+        </li>
+        <li class="run-flow-item">
+          <span class="run-flow-number">6</span>
+          <div>
+            <strong>Run a final chapter edit</strong>
+            <p class="field-note">Each saved chapter gets a polish pass for clarity, sentence rhythm, transitions, and concrete on-page consequences before final QA/export.</p>
           </div>
         </li>
       </ol>
@@ -667,7 +719,7 @@
   </aside>
 </section>
 
-<section class="panel">
+<section class="panel" id="run-history">
   <div class="section-header">
     <div class="section-header-copy">
       <h2>Run history</h2>

--- a/src/novel_generator/templates/run_detail.html
+++ b/src/novel_generator/templates/run_detail.html
@@ -10,6 +10,7 @@
   data-run-status="{{ run.status.value }}"
   data-run-step="{{ run.current_step }}"
   data-run-current-chapter="{{ run.current_chapter or '' }}"
+  data-run-requested-chapters="{{ run.requested_chapters }}"
   data-run-created-at="{{ run.created_at.strftime('%Y-%m-%dT%H:%M:%SZ') }}"
   data-run-started-at="{{ run.started_at.strftime('%Y-%m-%dT%H:%M:%SZ') if run.started_at else '' }}"
   data-run-completed-at="{{ run.completed_at.strftime('%Y-%m-%dT%H:%M:%SZ') if run.completed_at else '' }}"
@@ -81,6 +82,27 @@
         <span class="detail-label">Events</span>
         <strong data-run-event-count>{{ event_count }}</strong>
         <span class="field-note"><span data-run-artifact-count>{{ run.artifacts|length }}</span> artifacts</span>
+      </div>
+    </div>
+
+    <div class="run-progress-rails">
+      <div class="progress-rail">
+        <div class="progress-rail-topline">
+          <span class="detail-label">Chapter completion</span>
+          <strong data-run-chapter-progress-label>{{ completed_chapter_count }} / {{ run.requested_chapters }}</strong>
+        </div>
+        <div class="progress-track" aria-hidden="true">
+          <span data-run-chapter-progress-bar style="width: {{ (completed_chapter_count / run.requested_chapters * 100)|round(0, 'floor') if run.requested_chapters else 0 }}%"></span>
+        </div>
+      </div>
+      <div class="progress-rail">
+        <div class="progress-rail-topline">
+          <span class="detail-label">Word target</span>
+          <strong><span data-run-word-progress-label>{{ word_progress_percent }}%</span></strong>
+        </div>
+        <div class="progress-track" aria-hidden="true">
+          <span data-run-word-progress-bar style="width: {{ word_progress_percent }}%"></span>
+        </div>
       </div>
     </div>
 
@@ -165,6 +187,28 @@
       </div>
     </details>
   </div>
+
+  <section class="book-completion-panel" data-book-completion>
+    <div class="section-header">
+      <div class="section-header-copy">
+        <p class="eyebrow">Complete book target</p>
+        <h2>{{ book_completion.title }}</h2>
+        <p>{{ book_completion.body }}</p>
+      </div>
+      <div class="book-completion-score">
+        <strong>{{ book_completion.percent }}%</strong>
+        <span class="field-note">package ready</span>
+      </div>
+    </div>
+    <div class="book-completion-grid">
+      {% for item in book_completion.rows %}
+        <div class="book-completion-item book-completion-{{ item.tone }}">
+          <span class="detail-label">{{ item.label }}</span>
+          <strong>{{ item.current }} / {{ item.target }}</strong>
+        </div>
+      {% endfor %}
+    </div>
+  </section>
 
   <div class="run-stepper" data-run-stepper>
     {% for stage in run_stages %}
@@ -888,6 +932,24 @@
             </details>
           {% endif %}
 
+          {% if awaiting_outline_approval %}
+            <div class="outline-review-dock" data-outline-review-dock>
+              <div>
+                <span class="detail-label">Approval controls</span>
+                <strong>{{ outline_review.chapter_count }} chapter{{ "" if outline_review.chapter_count == 1 else "s" }} ready for review</strong>
+                <p class="field-note">These controls stay near the outline so a 32 or 64 chapter review can finish without scrolling back to the top.</p>
+              </div>
+              <div class="hero-actions">
+                <form method="post" action="/runs/{{ run.id }}/approve-outline">
+                  <button type="submit">Approve and continue</button>
+                </form>
+                <form method="post" action="/runs/{{ run.id }}/cancel-and-edit" data-confirm="Cancel this paused run and reopen the project editor so you can adjust the brief or defaults?">
+                  <button class="secondary" type="submit">Cancel and edit project</button>
+                </form>
+              </div>
+            </div>
+          {% endif %}
+
           <div class="outline-filter-bar">
             <label>
               Act
@@ -1141,10 +1203,55 @@
     <p>{{ run.chapters|length }} tracked</p>
   </div>
   {% if chapter_review_cards %}
+    <div class="chapter-review-toolbar" data-chapter-review-toolbar>
+      <div class="chapter-review-controls">
+        <label>
+          View
+          <select data-chapter-status-filter>
+            <option value="">All chapters</option>
+            <option value="current">Current chapter</option>
+            <option value="complete">Complete chapters</option>
+            <option value="risk">Needs review</option>
+            <option value="pending">Pending output</option>
+          </select>
+        </label>
+        <label>
+          Jump
+          <input type="number" min="1" max="{{ run.requested_chapters }}" value="{{ run.current_chapter or 1 }}" data-chapter-jump-input>
+        </label>
+        <div class="outline-filter-actions">
+          <button class="secondary" type="button" data-chapter-jump>Jump</button>
+          <button class="secondary" type="button" data-chapter-clear>Reset</button>
+        </div>
+      </div>
+      <p class="field-note"><span data-chapter-visible-count>{{ chapter_review_cards|length }} chapters visible</span></p>
+      <nav class="chapter-anchor-list" aria-label="Drafted chapters">
+        {% for card in chapter_review_cards %}
+          {% set chapter = card.chapter %}
+          <a
+            href="#chapter-{{ chapter.chapter_number }}"
+            class="chapter-anchor status-{{ chapter.status.value }}{% if card.has_risk %} has-risk{% endif %}{% if run.current_chapter == chapter.chapter_number %} is-current{% endif %}"
+            data-chapter-anchor="{{ chapter.chapter_number }}"
+          >
+            {{ chapter.chapter_number }}
+          </a>
+        {% endfor %}
+      </nav>
+      <p class="empty-state is-hidden" data-chapter-empty>No chapters match the current filter.</p>
+    </div>
     <div class="chapter-list">
       {% for card in chapter_review_cards %}
         {% set chapter = card.chapter %}
-        <article class="chapter-card{% if run.current_chapter == chapter.chapter_number %} active-chapter{% endif %}">
+        <article
+          id="chapter-{{ chapter.chapter_number }}"
+          class="chapter-card{% if run.current_chapter == chapter.chapter_number %} active-chapter{% endif %}"
+          data-chapter-card
+          data-chapter-number="{{ chapter.chapter_number }}"
+          data-chapter-status="{{ chapter.status.value }}"
+          data-chapter-current="{{ 'true' if run.current_chapter == chapter.chapter_number else 'false' }}"
+          data-chapter-risk="{{ 'true' if card.has_risk else 'false' }}"
+          data-chapter-has-content="{{ 'true' if chapter.content else 'false' }}"
+        >
           <div class="chapter-topline">
             <div class="chapter-heading">
               <p class="eyebrow">Chapter {{ chapter.chapter_number }}</p>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -39,23 +39,23 @@ def create_project_and_run(
     client,
     *,
     pause_after_outline: bool = True,
-    developmental_rewrite_enabled: bool = False,
+    developmental_rewrite_enabled: bool | None = None,
     quality_profile: str = "balanced",
 ) -> tuple[str, str]:
     project_response = client.post("/api/projects", json=create_project_payload())
     assert project_response.status_code == 201
     project_id = project_response.json()["id"]
 
-    run_response = client.post(
-        "/api/runs",
-        json={
-            "project_id": project_id,
-            "model_name": "test-model",
-            "pause_after_outline": pause_after_outline,
-            "developmental_rewrite_enabled": developmental_rewrite_enabled,
-            "quality_profile": quality_profile,
-        },
-    )
+    run_payload = {
+        "project_id": project_id,
+        "model_name": "test-model",
+        "pause_after_outline": pause_after_outline,
+        "quality_profile": quality_profile,
+    }
+    if developmental_rewrite_enabled is not None:
+        run_payload["developmental_rewrite_enabled"] = developmental_rewrite_enabled
+
+    run_response = client.post("/api/runs", json=run_payload)
     assert run_response.status_code == 201
     return project_id, run_response.json()["id"]
 
@@ -69,7 +69,7 @@ def test_project_and_run_api_flow(client, monkeypatch) -> None:
     assert detail_response.status_code == 200
     assert detail_response.json()["project_id"] == project_id
     assert detail_response.json()["pause_after_outline"] is True
-    assert detail_response.json()["developmental_rewrite_enabled"] is False
+    assert detail_response.json()["developmental_rewrite_enabled"] is True
     assert detail_response.json()["quality_profile"] == "balanced"
 
     cancel_response = client.post(f"/api/runs/{run_id}/cancel")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -75,9 +75,40 @@ def test_quality_profile_migration_defaults_existing_runs(tmp_path: Path, monkey
 
     command.upgrade(config, "head")
 
-    with engine.connect() as connection:
+    with engine.begin() as connection:
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO generation_runs (
+                    id, project_id, source_run_id, model_name, target_word_count,
+                    requested_chapters, min_words_per_chapter, max_words_per_chapter,
+                    status, current_step, current_chapter, outline, summary_context,
+                    error_message, cancel_requested, resume_from_chapter, created_at,
+                    started_at, completed_at, updated_at, pipeline_version,
+                    pause_after_outline, story_bible, continuity_ledger, provider_name,
+                    task_routing, worker_id, last_heartbeat_at, recovery_count
+                )
+                VALUES (
+                    'run-default', 'project-1', NULL, 'test-model', 4000,
+                    4, 800, 1200, 'QUEUED', 'queued', NULL, NULL, NULL,
+                    NULL, 0, NULL, :now, NULL, NULL, :now, 2,
+                    1, NULL, NULL, 'ollama', '{}', NULL, NULL, 0
+                )
+                """
+            ),
+            {"now": now},
+        )
+
         quality_profile = connection.scalar(sa.text("SELECT quality_profile FROM generation_runs WHERE id = 'run-1'"))
+        existing_rewrite_flag = connection.scalar(
+            sa.text("SELECT developmental_rewrite_enabled FROM generation_runs WHERE id = 'run-1'")
+        )
+        default_rewrite_flag = connection.scalar(
+            sa.text("SELECT developmental_rewrite_enabled FROM generation_runs WHERE id = 'run-default'")
+        )
     assert quality_profile == "balanced"
+    assert existing_rewrite_flag in (0, False)
+    assert default_rewrite_flag in (1, True)
 
     get_settings.cache_clear()
     get_session_factory.cache_clear()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -805,8 +805,10 @@ def test_approved_run_completes_and_generates_qa_report(configured_environment) 
         assert all(chapter.content for chapter in refreshed.chapters)
         assert all(chapter.summary for chapter in refreshed.chapters)
         assert all(chapter.continuity_update for chapter in refreshed.chapters)
-        assert len(refreshed.artifacts) == 3
+        assert len(refreshed.artifacts) == 6
         assert any(artifact.kind == "qa-report" for artifact in refreshed.artifacts)
+        assert any(artifact.kind == "developmental-rewrite-report" for artifact in refreshed.artifacts)
+        assert any(event.event_type == "final_editing_completed" for event in refreshed.events)
         assert refreshed.summary_context is not None
 
 
@@ -858,6 +860,57 @@ def test_developmental_rewrite_pass_exports_report_and_revised_outline(configure
         assert "revised-outline" in artifact_kinds
         assert "developmental-qa-report" in artifact_kinds
         assert any(event.event_type == "developmental_rewrite_completed" for event in refreshed.events)
+
+
+def test_final_editing_pass_polishes_saved_chapter_before_export(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=1)
+        run = create_run(
+            session,
+            project,
+            RunCreate(project_id=project.id, model_name="test-model", pause_after_outline=False),
+        )
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient(
+                [
+                    _story_bible_json(),
+                    _outline_json(1),
+                    _plan_json(1),
+                    (
+                        "Iris slips out of the archive while Tarin resists following her. "
+                        "Trigger 1 arrives when the visible actor 1 seals the corridor, leaving only route 1 below them."
+                    ),
+                    _critique_json(revision_required=False),
+                    "Iris chooses the lower route and accepts the cost of leaving the archive behind.",
+                    _continuity_json(1),
+                    _qa_report_json(),
+                    _developmental_rewrite_json(),
+                    (
+                        "Iris slipped out of the archive with grit under her nails while Tarin held the sealed map case "
+                        "like a debt. When the visible actor 1 sealed the corridor, she chose the lower route and left "
+                        "her last safe exit behind."
+                    ),
+                    _qa_report_json(),
+                ]
+            ),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.COMPLETED
+        chapter = refreshed.chapters[0]
+        assert chapter.content.startswith("Iris slipped out of the archive with grit")
+        assert "last safe exit" in chapter.content
+        assert any(event.event_type == "final_chapter_edit_completed" for event in refreshed.events)
+        assert any(attempt.stage == "chapter_edit" and attempt.status == "success" for attempt in refreshed.stage_attempts)
 
 
 def test_manuscript_qa_fallback_completes_when_model_output_stays_invalid(configured_environment) -> None:

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -288,10 +288,22 @@ def test_project_detail_renders_quality_profile_controls_and_preflight(client, m
     assert 'value="balanced"' in response.text
     assert "Run preflight" in response.text
     assert 'data-run-preflight' in response.text
+    assert 'href="#queue-run"' in response.text
+    assert 'id="queue-run"' in response.text
+    assert 'id="run-history"' in response.text
+    assert 'id="edit-project"' in response.text
+    assert "Full project brief" in response.text
     assert "Estimated model calls" in response.text
-    assert "23 minimum" in response.text
+    assert "29 minimum" in response.text
     assert "Stage attempt ledger" in response.text
     assert "Checkpoint resume" in response.text
+    assert 'data-run-queue-form' in response.text
+    assert 'data-run-target-words' in response.text
+    assert 'data-run-chapter-count' in response.text
+    assert 'data-run-length-preset="32"' in response.text
+    assert 'data-run-length-preset="64"' in response.text
+    assert 'data-run-estimate' in response.text
+    assert 'data-run-estimate-calls' in response.text
 
 
 def test_project_detail_preflight_warns_for_64_chapter_runs(client, monkeypatch) -> None:
@@ -303,7 +315,7 @@ def test_project_detail_preflight_warns_for_64_chapter_runs(client, monkeypatch)
     assert response.status_code == 200
     assert "64 chapters will use 8 outline chunks" in response.text
     assert "High chapter counts make checkpoint resume" in response.text
-    assert "330 minimum" in response.text
+    assert "396 minimum" in response.text
 
 
 def test_notice_tone_renders_warning_notice_class(client, monkeypatch) -> None:
@@ -452,6 +464,10 @@ def test_run_detail_renders_stepper_and_event_log_hooks(client, monkeypatch) -> 
     assert 'data-run-elapsed' in response.text
     assert "What The Worker Is Doing" in response.text
     assert "Run confidence" in response.text
+    assert "Complete book target" in response.text
+    assert 'data-run-chapter-progress-bar' in response.text
+    assert 'data-run-word-progress-bar' in response.text
+    assert 'data-book-completion' in response.text
     assert "Running: Draft chapter" in response.text
     assert "Next milestone" in response.text
     assert "Current Chapter Contract" in response.text
@@ -601,6 +617,7 @@ def test_run_detail_renders_outline_approval_controls(client, monkeypatch) -> No
     assert "Chapter-mode distribution" in response.text
     assert 'data-outline-workspace' in response.text
     assert 'data-outline-act-filter' in response.text
+    assert 'data-outline-review-dock' in response.text
     assert 'id="outline-chapter-1"' in response.text
     assert "Character agendas" in response.text
     assert "Canon registry" in response.text
@@ -675,6 +692,7 @@ def test_outline_review_workspace_renders_sixty_four_chapter_navigation(client, 
     assert 'id="outline-chapter-64"' in response.text
     assert 'data-outline-anchor="64"' in response.text
     assert 'data-outline-jump-input' in response.text
+    assert 'data-outline-review-dock' in response.text
     assert "64 / 64" in response.text
     assert "Approve and continue" in response.text
     assert "Cancel and edit project" in response.text
@@ -879,6 +897,52 @@ def test_run_detail_surfaces_rich_chapter_qa_notes(client, monkeypatch) -> None:
     assert "tracking Nora" in response.text
 
 
+def test_run_detail_renders_sixty_four_chapter_review_navigation(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
+    _, run_id = seed_project_and_run()
+
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        run = get_run(session, run_id)
+        assert run is not None
+        run.status = RunStatus.RUNNING
+        run.current_step = "chapter_draft"
+        run.current_chapter = 32
+        run.requested_chapters = 64
+        run.target_word_count = 64000
+        run.outline = [outline_entry(chapter_number, total_chapters=64) for chapter_number in range(1, 65)]
+        create_chapters_from_outline(session, run)
+        for chapter in run.chapters:
+            if chapter.chapter_number <= 31:
+                chapter.status = ChapterStatus.COMPLETED
+                chapter.content = f"Completed chapter {chapter.chapter_number} prose."
+                chapter.summary = f"Summary for chapter {chapter.chapter_number}."
+                chapter.word_count = 1000
+                chapter.continuity_update = {"chapter_outcome": f"Outcome {chapter.chapter_number}"}
+                chapter.qa_notes = {"strengths": ["Stable."], "revision_required": False}
+            if chapter.chapter_number == 32:
+                chapter.qa_notes = {
+                    "warnings": ["The midpoint ending is abstract."],
+                    "revision_required": True,
+                    "ending_concreteness_score": 4,
+                    "technical_escalation_fatigue_score": 7,
+                }
+        session.commit()
+
+    response = client.get(f"/runs/{run_id}")
+
+    assert response.status_code == 200
+    assert 'data-chapter-review-toolbar' in response.text
+    assert 'data-chapter-status-filter' in response.text
+    assert 'data-chapter-jump-input' in response.text
+    assert 'href="#chapter-64"' in response.text
+    assert 'id="chapter-64"' in response.text
+    assert 'data-chapter-anchor="64"' in response.text
+    assert 'data-chapter-risk="true"' in response.text
+    assert "Needs review" in response.text
+    assert "31 / 64" in response.text
+
+
 def test_project_detail_renders_cleanup_controls_for_finished_runs(client, monkeypatch) -> None:
     monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
     project_id, run_id = seed_project_and_run()
@@ -929,7 +993,7 @@ def test_project_run_setup_warns_for_external_default_provider(client, monkeypat
     assert "This route may send manuscript text and story data to the configured external provider." in response.text
     assert "Full novel runs can use large prompts" in response.text
     assert "Chapter draft: OpenAI-compatible API" in response.text
-    assert "Run developmental rewrite planning" in response.text
+    assert "Include developmental rewrite planning" in response.text
     assert "Developmental rewrite: OpenAI-compatible API" in response.text
 
 


### PR DESCRIPTION
## Summary
- adds run-confidence UI refinements for long 32/64 chapter workflows, including clearer project/run controls and book-completion progress
- makes developmental rewrite planning standard for new runs and adds a final chapter edit pass before final QA/export
- documents the benchmarked `gemma4:e4b` model and local rig details in the README
- adds migration `0007_standard_polish_pass` so fresh database defaults match the standard polish workflow

## Validation
- `docker compose exec -T web python -m pytest tests/test_migrations.py`
- `docker compose exec -T web python -m pytest`
- `git diff --check`
- `docker compose up --build -d web worker`
- smoke checked `/api/health`, `/`, `/projects`, `/settings/provider`, an existing project detail page, and an existing run detail page