### PR TITLE
[codex] Add manuscript edition workspace

### DIFF
--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -1834,7 +1834,21 @@ def _review_chip(label: str, tone: str = "neutral") -> dict[str, str]:
     return {"label": label, "tone": tone}
 
 
-def _chapter_status_chips(chapter: Any) -> list[dict[str, str]]:
+def _chapter_final_edit_numbers(run: GenerationRun) -> set[int]:
+    numbers: set[int] = set()
+    for event in _sorted_run_events(run):
+        if event.event_type != "final_chapter_edit_completed":
+            continue
+        try:
+            chapter_number = int((event.payload or {}).get("chapter_number") or 0)
+        except (TypeError, ValueError):
+            chapter_number = 0
+        if chapter_number:
+            numbers.add(chapter_number)
+    return numbers
+
+
+def _chapter_status_chips(chapter: Any, *, final_edit_completed: bool = False) -> list[dict[str, str]]:
     chips: list[dict[str, str]] = []
     if chapter.word_count:
         chips.append(_review_chip(f"{chapter.word_count} words", "neutral"))
@@ -1844,6 +1858,8 @@ def _chapter_status_chips(chapter: Any) -> list[dict[str, str]]:
         chips.append(_review_chip("Continuity updated", "success"))
     if chapter.qa_notes:
         chips.append(_review_chip("QA stored", "success"))
+    if final_edit_completed:
+        chips.append(_review_chip("Final edit saved", "success"))
     if chapter.content:
         chips.append(_review_chip("Preview ready", "success"))
     if chapter.error_message:
@@ -1895,18 +1911,157 @@ def _chapter_continuity_chips(chapter: Any) -> list[dict[str, str]]:
 
 def _chapter_review_cards(run: GenerationRun) -> list[dict[str, Any]]:
     cards: list[dict[str, Any]] = []
+    final_edit_numbers = _chapter_final_edit_numbers(run)
     for chapter in _sorted_run_chapters(run):
         risk_chips = _chapter_risk_chips(chapter)
+        final_edit_completed = chapter.chapter_number in final_edit_numbers
         cards.append(
             {
                 "chapter": chapter,
-                "status_chips": _chapter_status_chips(chapter),
+                "status_chips": _chapter_status_chips(chapter, final_edit_completed=final_edit_completed),
                 "risk_chips": risk_chips,
                 "continuity_chips": _chapter_continuity_chips(chapter),
                 "has_risk": any(chip["tone"] in {"risk", "warning"} for chip in risk_chips),
+                "final_edit_completed": final_edit_completed,
             }
         )
     return cards
+
+
+def _artifact_group_context(run: GenerationRun) -> list[dict[str, Any]]:
+    groups = [
+        {
+            "id": "manuscript",
+            "label": "Manuscript exports",
+            "description": "Primary draft files generated from the latest saved chapter prose.",
+            "empty": "Draft manuscript exports appear after the run completes.",
+            "artifacts": [],
+        },
+        {
+            "id": "publication",
+            "label": "Publication helpers",
+            "description": "Optional ebook and print-helper outputs created from the completed run.",
+            "empty": "Create an ebook or print-helper export when this edition is ready for formatting review.",
+            "artifacts": [],
+        },
+        {
+            "id": "editorial",
+            "label": "Editorial reports",
+            "description": "QA and developmental planning artifacts for deciding the next revision move.",
+            "empty": "QA and editorial reports appear when their stages finish.",
+            "artifacts": [],
+        },
+    ]
+    lookup = {group["id"]: group for group in groups}
+    for artifact in sorted(run.artifacts, key=lambda item: (item.kind, item.filename)):
+        if artifact.kind in {"markdown", "docx"}:
+            lookup["manuscript"]["artifacts"].append(artifact)
+        elif artifact.kind.startswith("publication-"):
+            lookup["publication"]["artifacts"].append(artifact)
+        else:
+            lookup["editorial"]["artifacts"].append(artifact)
+    return groups
+
+
+def _manuscript_edition_context(run: GenerationRun, chapter_cards: list[dict[str, Any]]) -> dict[str, Any]:
+    chapters = _sorted_run_chapters(run)
+    completed_runs = [
+        candidate
+        for candidate in _sort_runs(run.project)
+        if candidate.status == RunStatus.COMPLETED
+    ]
+    completed_oldest_first = list(reversed(completed_runs))
+    completed_ids = [candidate.id for candidate in completed_oldest_first]
+    edition_number = (
+        completed_ids.index(run.id) + 1
+        if run.id in completed_ids
+        else len(completed_oldest_first) + 1
+    )
+    latest_completed = completed_runs[0] if completed_runs else None
+    is_current_edition = run.status == RunStatus.COMPLETED and latest_completed is not None and latest_completed.id == run.id
+    total_words = _run_word_count(run)
+    completed_chapters = len([chapter for chapter in chapters if chapter.status == ChapterStatus.COMPLETED and chapter.content])
+    qa_chapters = len([chapter for chapter in chapters if chapter.qa_notes])
+    final_edit_numbers = _chapter_final_edit_numbers(run)
+    risk_chapters = [card for card in chapter_cards if card["has_risk"]]
+    missing_chapters = [chapter for chapter in chapters if not chapter.content]
+    manuscript_artifacts = [artifact for artifact in run.artifacts if artifact.kind in {"markdown", "docx"}]
+    publication_artifacts = [artifact for artifact in run.artifacts if artifact.kind.startswith("publication-")]
+    qa_artifact = next((artifact for artifact in run.artifacts if artifact.kind == "qa-report"), None)
+    primary_artifact = next((artifact for artifact in manuscript_artifacts if artifact.kind == "docx"), None) or next(
+        (artifact for artifact in manuscript_artifacts if artifact.kind == "markdown"),
+        None,
+    )
+
+    word_rows: list[dict[str, Any]] = []
+    within_target_count = 0
+    for card in chapter_cards:
+        chapter = card["chapter"]
+        word_count = int(chapter.word_count or 0)
+        if not chapter.content:
+            tone = "pending"
+            label = "Missing prose"
+        elif word_count < run.min_words_per_chapter:
+            tone = "warning"
+            label = "Below target"
+        elif word_count > run.max_words_per_chapter:
+            tone = "warning"
+            label = "Above target"
+        else:
+            tone = "success"
+            label = "In range"
+            within_target_count += 1
+        word_rows.append(
+            {
+                "chapter_number": chapter.chapter_number,
+                "title": chapter.title,
+                "word_count": word_count,
+                "tone": tone,
+                "label": label,
+                "has_risk": card["has_risk"],
+                "final_edit_completed": card["final_edit_completed"],
+                "status": chapter.status.value,
+            }
+        )
+
+    shortest = min((row for row in word_rows if row["word_count"]), key=lambda row: row["word_count"], default=None)
+    longest = max((row for row in word_rows if row["word_count"]), key=lambda row: row["word_count"], default=None)
+    average_words = round(total_words / completed_chapters) if completed_chapters else 0
+
+    if run.status == RunStatus.COMPLETED and is_current_edition:
+        snapshot_label = "Current generated edition"
+    elif run.status == RunStatus.COMPLETED:
+        snapshot_label = "Earlier completed edition"
+    elif run.status in TERMINAL_STATUSES:
+        snapshot_label = "Partial run snapshot"
+    else:
+        snapshot_label = "In-progress edition draft"
+
+    return {
+        "show": bool(chapters) or bool(run.artifacts),
+        "snapshot_label": snapshot_label,
+        "edition_number": edition_number,
+        "is_current_edition": is_current_edition,
+        "complete": run.status == RunStatus.COMPLETED and not missing_chapters,
+        "total_words": total_words,
+        "target_words": run.target_word_count,
+        "word_percent": _word_progress_percent(run),
+        "average_words": average_words,
+        "shortest": shortest,
+        "longest": longest,
+        "completed_chapters": completed_chapters,
+        "requested_chapters": run.requested_chapters,
+        "qa_chapters": qa_chapters,
+        "final_edit_chapters": len(final_edit_numbers),
+        "risk_chapters": len(risk_chapters),
+        "missing_chapters": len(missing_chapters),
+        "within_target_count": within_target_count,
+        "word_rows": word_rows,
+        "artifact_groups": _artifact_group_context(run),
+        "primary_artifact": primary_artifact,
+        "qa_artifact": qa_artifact,
+        "publication_artifacts": publication_artifacts,
+    }
 
 
 def _book_completion_context(run: GenerationRun) -> dict[str, Any]:
@@ -1944,7 +2099,8 @@ def _book_completion_context(run: GenerationRun) -> dict[str, Any]:
         row("Manuscript exports", manuscript_artifact_count, 1),
     ]
     required_complete = all(item["complete"] for item in rows)
-    percent = round((sum(min(item["current"], item["target"]) for item in rows) / sum(item["target"] for item in rows)) * 100)
+    raw_percent = round((sum(min(item["current"], item["target"]) for item in rows) / sum(item["target"] for item in rows)) * 100)
+    percent = raw_percent if required_complete else min(99, raw_percent)
     if run.status == RunStatus.COMPLETED and required_complete:
         title = "Complete book package"
         body = "All requested chapters, continuity checkpoints, QA, final edit, and manuscript exports are present."
@@ -3064,6 +3220,7 @@ def run_detail(
             "outline_review": outline_review,
             "chapter_review_cards": chapter_review_cards,
             "book_completion": _book_completion_context(run),
+            "manuscript_edition": _manuscript_edition_context(run, chapter_review_cards),
             "editorial_next_step": _run_editorial_next_step_context(run, chapter_review_cards),
             "story_bible": run.story_bible or {},
             "continuity_ledger": run.continuity_ledger or {},

--- a/src/novel_generator/static/style.css
+++ b/src/novel_generator/static/style.css
@@ -1405,6 +1405,174 @@ dd {
   background: rgba(255, 255, 255, 0.58);
 }
 
+.edition-workspace {
+  border-color: rgba(23, 106, 90, 0.2);
+}
+
+.edition-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.edition-stat,
+.edition-output-group,
+.edition-word-map {
+  padding: 0.85rem;
+  border: 1px solid rgba(217, 207, 192, 0.95);
+  border-radius: var(--radius);
+  background: rgba(255, 255, 255, 0.58);
+}
+
+.edition-stat {
+  display: grid;
+  gap: 0.25rem;
+  align-content: start;
+}
+
+.edition-stat strong {
+  font-size: clamp(1.15rem, 1.6vw, 1.45rem);
+  line-height: 1.1;
+}
+
+.edition-layout {
+  display: grid;
+  grid-template-columns: minmax(16rem, 0.85fr) minmax(0, 1.35fr);
+  gap: 1rem;
+  align-items: start;
+  margin-top: 1rem;
+}
+
+.edition-output-groups {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.edition-output-group {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.edition-group-topline {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: start;
+  flex-wrap: wrap;
+}
+
+.edition-artifact-links {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.edition-artifact-links a {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.6rem 0.7rem;
+  border: 1px solid rgba(212, 221, 215, 0.95);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.edition-artifact-links a:hover,
+.edition-artifact-links a:focus-visible {
+  border-color: rgba(23, 106, 90, 0.38);
+  background: rgba(23, 106, 90, 0.08);
+}
+
+.edition-word-map {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.edition-word-list {
+  display: grid;
+  gap: 0.35rem;
+  max-height: 24rem;
+  overflow: auto;
+  padding-right: 0.15rem;
+}
+
+.edition-word-row {
+  display: grid;
+  grid-template-columns: 2.1rem minmax(0, 1fr) 4.75rem 6.5rem auto auto;
+  gap: 0.55rem;
+  align-items: center;
+  min-height: 2.35rem;
+  padding: 0.45rem 0.55rem;
+  border: 1px solid rgba(212, 221, 215, 0.95);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+}
+
+.edition-word-row:hover,
+.edition-word-row:focus-visible {
+  border-color: rgba(23, 106, 90, 0.38);
+  background: rgba(23, 106, 90, 0.08);
+}
+
+.edition-word-success {
+  border-color: rgba(23, 101, 59, 0.2);
+}
+
+.edition-word-warning {
+  border-color: rgba(141, 104, 24, 0.25);
+  background: var(--warning-soft);
+}
+
+.edition-word-pending {
+  opacity: 0.82;
+}
+
+.edition-word-row.has-risk {
+  border-color: rgba(166, 66, 51, 0.26);
+}
+
+.edition-word-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.85rem;
+  height: 1.85rem;
+  border-radius: var(--radius-sm);
+  background: rgba(23, 106, 90, 0.1);
+  color: var(--accent-strong);
+  font-weight: 800;
+}
+
+.edition-word-title,
+.edition-word-count,
+.edition-word-label,
+.edition-word-flag {
+  font-size: 0.86rem;
+}
+
+.edition-word-count,
+.edition-word-label,
+.edition-word-flag {
+  font-weight: 700;
+}
+
+.edition-word-flag {
+  display: inline-flex;
+  justify-content: center;
+  padding: 0.24rem 0.45rem;
+  border-radius: 999px;
+  border: 1px solid rgba(23, 101, 59, 0.22);
+  background: var(--success-soft);
+  color: var(--success);
+}
+
+.edition-word-flag.risk {
+  border-color: rgba(166, 66, 51, 0.24);
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+
 .artifact-kind {
   text-transform: uppercase;
   letter-spacing: 0.08em;
@@ -2218,6 +2386,7 @@ code {
   .quick-action-grid,
   .stats-grid,
   .run-stepper,
+  .edition-layout,
   .checklist-item,
   .section-header,
   .chapter-topline,
@@ -2296,6 +2465,10 @@ code {
     grid-template-columns: 1fr;
   }
 
+  .edition-stat-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .regenerate-suggestion {
     grid-template-columns: 1fr;
   }
@@ -2341,6 +2514,20 @@ code {
   .run-setup-grid,
   .quick-action-grid {
     grid-template-columns: 1fr;
+  }
+
+  .edition-stat-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .edition-word-row {
+    grid-template-columns: 2.1rem minmax(0, 1fr);
+  }
+
+  .edition-word-count,
+  .edition-word-label,
+  .edition-word-flag {
+    justify-self: start;
   }
 
   .book-completion-grid {

--- a/src/novel_generator/static/ui.js
+++ b/src/novel_generator/static/ui.js
@@ -335,8 +335,11 @@ function setupChapterNavigator(root) {
     const jumpInput = toolbar.querySelector("[data-chapter-jump-input]");
     const jumpButton = toolbar.querySelector("[data-chapter-jump]");
     const clearButton = toolbar.querySelector("[data-chapter-clear]");
+    const openRiskyButton = toolbar.querySelector("[data-chapter-open-risky]");
+    const collapseButton = toolbar.querySelector("[data-chapter-collapse]");
     const visibleCount = toolbar.querySelector("[data-chapter-visible-count]");
     const emptyState = toolbar.querySelector("[data-chapter-empty]");
+    const reviewSections = Array.from(section?.querySelectorAll("[data-review-section]") || []);
 
     const setHidden = (node, hidden) => {
       if (node) {
@@ -413,6 +416,31 @@ function setupChapterNavigator(root) {
         statusFilter.value = "";
       }
       sync();
+    });
+    openRiskyButton?.addEventListener("click", () => {
+      if (statusFilter) {
+        statusFilter.value = "risk";
+      }
+      sync();
+      let firstRiskCard = null;
+      cards.forEach((card) => {
+        if (card.dataset.chapterRisk !== "true") {
+          return;
+        }
+        if (!firstRiskCard) {
+          firstRiskCard = card;
+        }
+        const firstReviewSection = card.querySelector("[data-review-section]");
+        if (firstReviewSection) {
+          firstReviewSection.open = true;
+        }
+      });
+      firstRiskCard?.scrollIntoView({ behavior: "smooth", block: "start" });
+    });
+    collapseButton?.addEventListener("click", () => {
+      reviewSections.forEach((reviewSection) => {
+        reviewSection.open = false;
+      });
     });
     sync();
   });

--- a/src/novel_generator/templates/run_detail.html
+++ b/src/novel_generator/templates/run_detail.html
@@ -210,6 +210,122 @@
     </div>
   </section>
 
+  {% if manuscript_edition.show %}
+    <section class="panel edition-workspace" id="manuscript-edition" data-edition-workspace>
+      <div class="section-header">
+        <div class="section-header-copy">
+          <p class="eyebrow">Manuscript edition</p>
+          <h2>Edition snapshot</h2>
+          <p>{{ manuscript_edition.snapshot_label }} #{{ manuscript_edition.edition_number }}. Use this workspace to verify chapter coverage, final-edit state, QA, and export readiness before treating the run as the book candidate.</p>
+        </div>
+        <div class="hero-actions">
+          {% if manuscript_edition.primary_artifact %}
+            <a class="button" href="/api/artifacts/{{ manuscript_edition.primary_artifact.id }}/download">Download manuscript</a>
+          {% endif %}
+          {% if manuscript_edition.qa_artifact %}
+            <a class="button secondary" href="/api/artifacts/{{ manuscript_edition.qa_artifact.id }}/download">Download QA</a>
+          {% endif %}
+          {% if run.status.value == "completed" %}
+            <a class="button secondary" href="#publication-export">Create publication export</a>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="edition-stat-grid">
+        <div class="edition-stat">
+          <span class="detail-label">Manuscript words</span>
+          <strong>{{ manuscript_edition.total_words }}</strong>
+          <span class="field-note">{{ manuscript_edition.word_percent }}% of {{ manuscript_edition.target_words }}</span>
+        </div>
+        <div class="edition-stat">
+          <span class="detail-label">Chapter coverage</span>
+          <strong>{{ manuscript_edition.completed_chapters }} / {{ manuscript_edition.requested_chapters }}</strong>
+          <span class="field-note">{{ manuscript_edition.missing_chapters }} missing prose</span>
+        </div>
+        <div class="edition-stat">
+          <span class="detail-label">Final edit</span>
+          <strong>{{ manuscript_edition.final_edit_chapters }} / {{ manuscript_edition.requested_chapters }}</strong>
+          <span class="field-note">chapter checkpoints</span>
+        </div>
+        <div class="edition-stat">
+          <span class="detail-label">QA coverage</span>
+          <strong>{{ manuscript_edition.qa_chapters }} / {{ manuscript_edition.requested_chapters }}</strong>
+          <span class="field-note">{{ manuscript_edition.risk_chapters }} chapters flagged</span>
+        </div>
+        <div class="edition-stat">
+          <span class="detail-label">Word range</span>
+          <strong>{{ manuscript_edition.within_target_count }} / {{ manuscript_edition.requested_chapters }}</strong>
+          <span class="field-note">{{ run.min_words_per_chapter }}-{{ run.max_words_per_chapter }} target</span>
+        </div>
+        <div class="edition-stat">
+          <span class="detail-label">Average chapter</span>
+          <strong>{{ manuscript_edition.average_words }}</strong>
+          <span class="field-note">words</span>
+        </div>
+      </div>
+
+      <div class="edition-layout">
+        <div class="edition-output-groups">
+          {% for group in manuscript_edition.artifact_groups %}
+            <article class="edition-output-group" data-edition-artifact-group="{{ group.id }}">
+              <div class="edition-group-topline">
+                <div>
+                  <strong>{{ group.label }}</strong>
+                  <p class="field-note">{{ group.description }}</p>
+                </div>
+                <span class="meta-chip">{{ group.artifacts|length }}</span>
+              </div>
+              {% if group.artifacts %}
+                <div class="edition-artifact-links">
+                  {% for artifact in group.artifacts %}
+                    <a href="/api/artifacts/{{ artifact.id }}/download">
+                      <span>{{ artifact.filename }}</span>
+                      <span class="artifact-kind">{{ artifact.kind }}</span>
+                    </a>
+                  {% endfor %}
+                </div>
+              {% else %}
+                <p class="empty-state">{{ group.empty }}</p>
+              {% endif %}
+            </article>
+          {% endfor %}
+        </div>
+
+        <div class="edition-word-map">
+          <div class="edition-group-topline">
+            <div>
+              <strong>Word-count map</strong>
+              <p class="field-note">Jump into outliers, flagged chapters, or chapters that missed the final edit checkpoint.</p>
+            </div>
+            {% if manuscript_edition.shortest and manuscript_edition.longest %}
+              <span class="meta-chip">Low {{ manuscript_edition.shortest.word_count }} / high {{ manuscript_edition.longest.word_count }}</span>
+            {% endif %}
+          </div>
+          <div class="edition-word-list">
+            {% for row in manuscript_edition.word_rows %}
+              <a
+                href="#chapter-{{ row.chapter_number }}"
+                class="edition-word-row edition-word-{{ row.tone }}{% if row.has_risk %} has-risk{% endif %}"
+                data-edition-word-row
+              >
+                <span class="edition-word-number">{{ row.chapter_number }}</span>
+                <span class="edition-word-title long-value">{{ row.title }}</span>
+                <span class="edition-word-count">{{ row.word_count }}</span>
+                <span class="edition-word-label">{{ row.label }}</span>
+                {% if row.final_edit_completed %}
+                  <span class="edition-word-flag">Edited</span>
+                {% endif %}
+                {% if row.has_risk %}
+                  <span class="edition-word-flag risk">Risk</span>
+                {% endif %}
+              </a>
+            {% endfor %}
+          </div>
+        </div>
+      </div>
+    </section>
+  {% endif %}
+
   <div class="run-stepper" data-run-stepper>
     {% for stage in run_stages %}
       <article class="run-stage" data-stage="{{ stage.id }}">
@@ -1222,6 +1338,8 @@
         <div class="outline-filter-actions">
           <button class="secondary" type="button" data-chapter-jump>Jump</button>
           <button class="secondary" type="button" data-chapter-clear>Reset</button>
+          <button class="secondary" type="button" data-chapter-open-risky>Open risky</button>
+          <button class="secondary" type="button" data-chapter-collapse>Collapse all</button>
         </div>
       </div>
       <p class="field-note"><span data-chapter-visible-count>{{ chapter_review_cards|length }} chapters visible</span></p>
@@ -1251,6 +1369,7 @@
           data-chapter-current="{{ 'true' if run.current_chapter == chapter.chapter_number else 'false' }}"
           data-chapter-risk="{{ 'true' if card.has_risk else 'false' }}"
           data-chapter-has-content="{{ 'true' if chapter.content else 'false' }}"
+          data-chapter-final-edit="{{ 'true' if card.final_edit_completed else 'false' }}"
         >
           <div class="chapter-topline">
             <div class="chapter-heading">

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -793,6 +793,94 @@ def test_completed_run_can_create_publication_export(client, monkeypatch) -> Non
         assert any(event.event_type == "publication_export_created" for event in run.events)
 
 
+def test_completed_long_run_renders_manuscript_edition_workspace(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
+    _, run_id = seed_project_and_run()
+
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        run = get_run(session, run_id)
+        assert run is not None
+        run.status = RunStatus.COMPLETED
+        run.current_step = "completed"
+        run.requested_chapters = 64
+        run.target_word_count = 64000
+        run.outline = [outline_entry(chapter_number, total_chapters=64) for chapter_number in range(1, 65)]
+        create_chapters_from_outline(session, run)
+        for chapter in run.chapters:
+            chapter.status = ChapterStatus.COMPLETED
+            chapter.content = f"Completed chapter {chapter.chapter_number} prose with a concrete final beat."
+            chapter.summary = f"Summary for chapter {chapter.chapter_number}."
+            chapter.word_count = 700 if chapter.chapter_number == 8 else 1000
+            chapter.continuity_update = {"chapter_outcome": f"Outcome {chapter.chapter_number}"}
+            chapter.qa_notes = {
+                "strengths": ["Stable chapter motion."],
+                "warnings": ["Ending still needs a sharper object."] if chapter.chapter_number == 8 else [],
+                "revision_required": chapter.chapter_number == 8,
+                "ending_concreteness_score": 4 if chapter.chapter_number == 8 else 8,
+                "technical_escalation_fatigue_score": 7 if chapter.chapter_number == 8 else 2,
+            }
+            record_event(
+                session,
+                run,
+                "final_chapter_edit_completed",
+                {"chapter_number": chapter.chapter_number, "message": f"Final edit completed for chapter {chapter.chapter_number}."},
+            )
+        run.artifacts.append(
+            Artifact(
+                kind="markdown",
+                filename="manuscript.md",
+                relative_path=f"{run.id}/manuscript.md",
+                content_type="text/markdown",
+            )
+        )
+        run.artifacts.append(
+            Artifact(
+                kind="docx",
+                filename="manuscript.docx",
+                relative_path=f"{run.id}/manuscript.docx",
+                content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+        )
+        run.artifacts.append(
+            Artifact(
+                kind="qa-report",
+                filename="qa-report.md",
+                relative_path=f"{run.id}/qa-report.md",
+                content_type="text/markdown",
+            )
+        )
+        run.artifacts.append(
+            Artifact(
+                kind="publication-docx",
+                filename="publication-print-6x9.docx",
+                relative_path=f"{run.id}/publication-print-6x9.docx",
+                content_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            )
+        )
+        session.commit()
+
+    response = client.get(f"/runs/{run_id}")
+
+    assert response.status_code == 200
+    assert 'data-edition-workspace' in response.text
+    assert "Edition snapshot" in response.text
+    assert "Current generated edition #1" in response.text
+    assert "Word-count map" in response.text
+    assert response.text.count("data-edition-word-row") == 64
+    assert 'data-edition-artifact-group="manuscript"' in response.text
+    assert 'data-edition-artifact-group="publication"' in response.text
+    assert 'data-edition-artifact-group="editorial"' in response.text
+    assert "64 / 64" in response.text
+    assert "Below target" in response.text
+    assert "Edited" in response.text
+    assert "Risk" in response.text
+    assert 'data-chapter-final-edit="true"' in response.text
+    assert "Final edit saved" in response.text
+    assert "Open risky" in response.text
+    assert "Collapse all" in response.text
+
+
 def test_run_detail_surfaces_rich_chapter_qa_notes(client, monkeypatch) -> None:
     monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
     _, run_id = seed_project_and_run()


### PR DESCRIPTION
## Summary
- adds a manuscript edition workspace to run detail pages with edition status, word/QA/final-edit coverage, grouped artifacts, and a chapter word-count map
- surfaces final-edit completion on chapter cards and data hooks for long-run scanning
- adds chapter-review controls to open risky chapters and collapse expanded review sections
- caps book-completion readiness below 100% until every required checkpoint is complete

## Validation
- `docker compose exec -T web python -m pytest tests/test_ui_routes.py::test_completed_long_run_renders_manuscript_edition_workspace tests/test_ui_routes.py::test_run_detail_renders_sixty_four_chapter_review_navigation tests/test_ui_routes.py::test_run_detail_surfaces_qa_report_artifact`
- `docker compose exec -T web python -m pytest`
- `git diff --check`
- `docker compose restart web`
- smoke checked `/api/health` and a completed 64-chapter run detail page
- Playwright screenshots: `C:\tmp\novel-generator-edition-workspace-desktop.png`, `C:\tmp\novel-generator-edition-workspace-mobile.png`