### PR TITLE
Harden Gemma long-run generation

### DIFF
--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -102,6 +102,13 @@ RUN_STAGES = [
         "result": "Quality signals and revision triggers should explain what the repair pass is trying to fix.",
     },
     {
+        "id": "chapter_expansion",
+        "label": "Expand chapter",
+        "description": "Filling out an under-length chapter before continuity is frozen.",
+        "why": "The worker is preserving the chapter outcome while adding dramatized scene work, dialogue, texture, and consequence to meet the requested book length.",
+        "result": "The chapter word count should move closer to the configured minimum before critique, summary, and continuity checkpoints continue.",
+    },
+    {
         "id": "chapter_summary",
         "label": "Update continuity",
         "description": "Saving the chapter summary and run-level continuity ledger.",
@@ -249,6 +256,7 @@ RUN_STAGE_PROGRESS_ORDER = [
     "outline_review",
     "chapter_plan",
     "chapter_draft",
+    "chapter_expansion",
     "chapter_revision",
     "chapter_summary",
     "manuscript_qa",
@@ -1462,7 +1470,7 @@ def _run_preflight_context(
 
     outline_chunks = (
         1
-        if requested_chapters <= PREFLIGHT_OUTLINE_CHUNK_THRESHOLD
+        if requested_chapters < PREFLIGHT_OUTLINE_CHUNK_THRESHOLD
         else max(1, (requested_chapters + PREFLIGHT_OUTLINE_CHUNK_SIZE - 1) // PREFLIGHT_OUTLINE_CHUNK_SIZE)
     )
     estimated_model_calls = 1 + outline_chunks + (requested_chapters * 5) + 1 + requested_chapters + 1
@@ -1487,7 +1495,7 @@ def _run_preflight_context(
     elif provider_status.available_models and model_name not in provider_status.available_models:
         warnings.append({"tone": "warning", "message": f"Model '{model_name}' is not in the detected model list."})
 
-    if requested_chapters > PREFLIGHT_OUTLINE_CHUNK_THRESHOLD:
+    if requested_chapters >= PREFLIGHT_OUTLINE_CHUNK_THRESHOLD:
         warnings.append(
             {
                 "tone": "warning",

--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -53,6 +53,7 @@ from .prompts import (
     build_chapter_critique_messages,
     build_chapter_draft_messages,
     build_chapter_edit_messages,
+    build_chapter_expansion_messages,
     build_chapter_plan_messages,
     build_chapter_revision_messages,
     build_developmental_revision_messages,
@@ -911,6 +912,97 @@ def _fallback_outline_entries(
     return entries
 
 
+def _outline_payload(outline: list[dict[str, Any]]) -> str:
+    return json.dumps({"chapters": outline})
+
+
+def _set_outline_breather_fields(item: dict[str, Any], fallback: dict[str, Any], story_bible: StoryBible) -> None:
+    if item.get("chapter_mode", "").lower() not in {"breather", "aftermath"}:
+        return
+    item["civilian_life_detail"] = item.get("civilian_life_detail") or fallback["civilian_life_detail"]
+    item["emotional_reveal"] = item.get("emotional_reveal") or fallback["emotional_reveal"]
+    item["ideology_pressure"] = item.get("ideology_pressure") or story_bible.theme or fallback["ideology_pressure"]
+
+
+def _repair_outline_for_full_book_validation(
+    project: Any,
+    story_bible: StoryBible,
+    outline: list[dict[str, Any]],
+    requested_chapters: int,
+    *,
+    rebalance_modes: bool = False,
+) -> list[dict[str, Any]]:
+    entries = [StructuredOutlineEntry.model_validate(item) for item in outline]
+    if len(entries) != requested_chapters:
+        raise ValueError(f"Cannot repair outline with {len(entries)} chapters; expected {requested_chapters}.")
+    expected_numbers = list(range(1, requested_chapters + 1))
+    actual_numbers = [entry.chapter_number for entry in entries]
+    if actual_numbers != expected_numbers:
+        raise ValueError("Cannot repair outline whose chapter numbers are not sequential.")
+
+    fallback_entries = {
+        item["chapter_number"]: item
+        for item in _fallback_outline_entries(project, story_bible, 1, requested_chapters, requested_chapters)
+    }
+    repaired = [entry.model_dump() for entry in entries]
+
+    if rebalance_modes:
+        for item in repaired:
+            item["chapter_mode"] = _fallback_chapter_mode(item["chapter_number"])
+
+    for item in repaired:
+        fallback = fallback_entries[item["chapter_number"]]
+        _set_outline_breather_fields(item, fallback, story_bible)
+
+    midpoint_chapter: int | None = None
+    if requested_chapters >= 3:
+        midpoint_start = max(2, (requested_chapters * 2 + 4) // 5)
+        midpoint_end = max(midpoint_start, (requested_chapters * 7) // 10)
+        midpoint_chapter = max(midpoint_start, min(midpoint_end, (midpoint_start + midpoint_end) // 2))
+        repaired[midpoint_chapter - 1]["outcome_type"] = "reversal"
+
+    minimum_setbacks = max(1, (requested_chapters * 3 + 9) // 10)
+    candidate_numbers: list[int] = []
+    if midpoint_chapter is not None:
+        candidate_numbers.append(midpoint_chapter)
+    candidate_numbers.extend(range(2, requested_chapters + 1, 2))
+    candidate_numbers.extend(range(5, requested_chapters + 1, 5))
+    candidate_numbers.append(requested_chapters)
+    candidate_numbers.extend(range(1, requested_chapters + 1))
+
+    seen_candidates: set[int] = set()
+    for chapter_number in candidate_numbers:
+        if chapter_number in seen_candidates:
+            continue
+        seen_candidates.add(chapter_number)
+        setback_count = sum(
+            1 for item in repaired if item.get("outcome_type", "").lower() in {"setback", "reversal"}
+        )
+        if setback_count >= minimum_setbacks:
+            break
+        item = repaired[chapter_number - 1]
+        if item.get("outcome_type", "").lower() not in {"setback", "reversal"}:
+            item["outcome_type"] = (
+                "reversal"
+                if chapter_number == requested_chapters
+                or chapter_number == midpoint_chapter
+                or chapter_number % 5 == 0
+                else "setback"
+            )
+
+    clean_win_streak = 0
+    for item in repaired:
+        if item.get("outcome_type", "").lower() == "win":
+            clean_win_streak += 1
+        else:
+            clean_win_streak = 0
+        if clean_win_streak > 2:
+            item["outcome_type"] = "setback"
+            clean_win_streak = 0
+
+    return repaired
+
+
 def _fallback_chapter_plan(
     chapter: Any,
     outline_entry: StructuredOutlineEntry,
@@ -1035,8 +1127,49 @@ def _validated_outline_or_fallback(
     outline: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     try:
-        return parse_outline(json.dumps({"chapters": outline}), run.requested_chapters)
+        return parse_outline(_outline_payload(outline), run.requested_chapters)
     except Exception as exc:
+        try:
+            repaired = _repair_outline_for_full_book_validation(
+                project,
+                story_bible,
+                outline,
+                run.requested_chapters,
+            )
+            parsed = parse_outline(_outline_payload(repaired), run.requested_chapters)
+            record_event(
+                session,
+                run,
+                "outline_validation_repaired",
+                {
+                    "message": "Combined outline failed full-book pacing validation; preserved generated chapters and repaired pacing fields.",
+                    "error": str(exc),
+                },
+            )
+            return parsed
+        except Exception as repair_exc:
+            try:
+                repaired = _repair_outline_for_full_book_validation(
+                    project,
+                    story_bible,
+                    outline,
+                    run.requested_chapters,
+                    rebalance_modes=True,
+                )
+                parsed = parse_outline(_outline_payload(repaired), run.requested_chapters)
+                record_event(
+                    session,
+                    run,
+                    "outline_validation_repaired",
+                    {
+                        "message": "Combined outline failed full-book pacing validation; preserved generated chapters and rebalanced pacing fields.",
+                        "error": str(exc),
+                        "repair_error": str(repair_exc),
+                    },
+                )
+                return parsed
+            except Exception as rebalance_exc:
+                fallback_error = rebalance_exc
         record_event(
             session,
             run,
@@ -1044,19 +1177,18 @@ def _validated_outline_or_fallback(
             {
                 "message": "Combined outline failed full-book validation; generated a deterministic outline.",
                 "error": str(exc),
+                "repair_error": str(fallback_error),
             },
         )
         return parse_outline(
-            json.dumps(
-                {
-                    "chapters": _fallback_outline_entries(
-                        project,
-                        story_bible,
-                        1,
-                        run.requested_chapters,
-                        run.requested_chapters,
-                    )
-                }
+            _outline_payload(
+                _fallback_outline_entries(
+                    project,
+                    story_bible,
+                    1,
+                    run.requested_chapters,
+                    run.requested_chapters,
+                )
             ),
             run.requested_chapters,
         )
@@ -1210,7 +1342,7 @@ def _generate_outline(session: Session, run: GenerationRun, story_bible: StoryBi
     )
     session.commit()
     try:
-        if run.requested_chapters > OUTLINE_CHUNK_THRESHOLD:
+        if run.requested_chapters >= OUTLINE_CHUNK_THRESHOLD:
             outline = _generate_outline_chunks(session, run, story_bible, client, provider_name, model_name)
         else:
             outline = _generate_structured_output(
@@ -1239,6 +1371,144 @@ def _generate_outline(session: Session, run: GenerationRun, story_bible: StoryBi
     create_chapters_from_outline(session, run)
     record_event(session, run, "outline_completed", {"chapters": len(run.outline or [])})
     session.commit()
+
+
+def _chapter_length_guard_enabled(run: GenerationRun) -> bool:
+    return run.min_words_per_chapter >= 1500 or run.target_word_count >= 10000
+
+
+def _expand_chapter_to_minimum(
+    session: Session,
+    run: GenerationRun,
+    chapter: Any,
+    outline_entry: StructuredOutlineEntry,
+    story_bible: StoryBible,
+    ledger: ContinuityLedger,
+    plan: ChapterPlan,
+    client: ProviderManager | OllamaClient,
+    *,
+    reason: str,
+) -> None:
+    chapter.word_count = len((chapter.content or "").split())
+    if (
+        not _chapter_length_guard_enabled(run)
+        or chapter.word_count >= run.min_words_per_chapter
+        or chapter.summary
+    ):
+        session.commit()
+        return
+
+    for pass_number in range(1, 3):
+        if chapter.word_count >= run.min_words_per_chapter:
+            break
+        _ensure_not_canceled(session, run)
+        provider_name, model_name = _resolve_stage_route(client, run, "chapter_revision")
+        before_word_count = chapter.word_count
+        run.current_step = "chapter_expansion"
+        run.current_chapter = chapter.chapter_number
+        record_event(
+            session,
+            run,
+            "chapter_expansion_started",
+            {
+                "message": f"Expanding chapter {chapter.chapter_number} toward the minimum word target.",
+                "chapter_number": chapter.chapter_number,
+                "before_word_count": before_word_count,
+                "target_min_words": run.min_words_per_chapter,
+                "target_max_words": run.max_words_per_chapter,
+                "pass_number": pass_number,
+                "reason": reason,
+                "provider_name": provider_name,
+                "model_name": model_name,
+            },
+        )
+        session.commit()
+        try:
+            expanded_content = sanitize_chapter_content(
+                _supervised_provider_chat(
+                    session,
+                    run,
+                    client,
+                    provider_name,
+                    model_name,
+                    build_chapter_expansion_messages(
+                        run.project,
+                        run,
+                        chapter,
+                        outline_entry,
+                        story_bible,
+                        ledger,
+                        plan,
+                    ),
+                    stage="chapter_expansion",
+                    chapter_number=chapter.chapter_number,
+                    metadata={
+                        "label": f"chapter {chapter.chapter_number} expansion",
+                        "reason": reason,
+                        "pass_number": pass_number,
+                        "before_word_count": before_word_count,
+                        "target_min_words": run.min_words_per_chapter,
+                    },
+                )
+            )
+            expanded_word_count = len(expanded_content.split())
+            if not expanded_content.strip():
+                raise RuntimeError(f"Chapter {chapter.chapter_number} expansion was empty.")
+            if expanded_word_count < before_word_count:
+                raise RuntimeError(
+                    f"Chapter {chapter.chapter_number} expansion shortened the chapter from "
+                    f"{before_word_count} to {expanded_word_count} words."
+                )
+            chapter.content = expanded_content
+            chapter.word_count = expanded_word_count
+            record_event(
+                session,
+                run,
+                "chapter_expansion_completed",
+                {
+                    "message": f"Chapter {chapter.chapter_number} expansion saved.",
+                    "chapter_number": chapter.chapter_number,
+                    "before_word_count": before_word_count,
+                    "after_word_count": chapter.word_count,
+                    "target_min_words": run.min_words_per_chapter,
+                    "pass_number": pass_number,
+                    "reason": reason,
+                },
+            )
+            session.commit()
+        except Exception as exc:
+            chapter.word_count = len((chapter.content or "").split())
+            record_event(
+                session,
+                run,
+                "chapter_expansion_fallback",
+                {
+                    "message": f"Chapter {chapter.chapter_number} expansion failed; keeping existing prose.",
+                    "chapter_number": chapter.chapter_number,
+                    "word_count": chapter.word_count,
+                    "target_min_words": run.min_words_per_chapter,
+                    "pass_number": pass_number,
+                    "reason": reason,
+                    "error": str(exc),
+                },
+            )
+            session.commit()
+            break
+
+    if chapter.word_count < run.min_words_per_chapter:
+        record_event(
+            session,
+            run,
+            "chapter_expansion_shortfall",
+            {
+                "message": f"Chapter {chapter.chapter_number} remains below the minimum word target.",
+                "chapter_number": chapter.chapter_number,
+                "word_count": chapter.word_count,
+                "target_min_words": run.min_words_per_chapter,
+                "reason": reason,
+            },
+        )
+        session.commit()
 
 
 def _pause_for_outline_review(session: Session, run: GenerationRun) -> None:
@@ -1378,6 +1648,18 @@ def _draft_chapter(
         )
         session.commit()
 
+    _expand_chapter_to_minimum(
+        session,
+        run,
+        chapter,
+        outline_entry,
+        story_bible,
+        ledger,
+        plan,
+        client,
+        reason="post_draft",
+    )
+
     _ensure_not_canceled(session, run)
     run.current_step = "chapter_revision"
     lint_result = lint_chapter(chapter, outline_entry, plan, story_bible, ledger, prior_chapters)
@@ -1479,6 +1761,18 @@ def _draft_chapter(
             raise RuntimeError(f"Chapter {chapter.chapter_number} revision was empty.")
         chapter.word_count = len((chapter.content or "").split())
         session.commit()
+
+        _expand_chapter_to_minimum(
+            session,
+            run,
+            chapter,
+            outline_entry,
+            story_bible,
+            ledger,
+            plan,
+            client,
+            reason="post_revision",
+        )
 
         final_lint = lint_chapter(chapter, outline_entry, plan, story_bible, ledger, prior_chapters)
         try:

--- a/src/novel_generator/services/prompts.py
+++ b/src/novel_generator/services/prompts.py
@@ -414,6 +414,7 @@ def build_outline_chunk_messages(
     profile = _story_bible_genre_profile(bible)
     chapter_mode_options = _chapter_mode_options()
     chapter_count = end_chapter - start_chapter + 1
+    minimum_local_setbacks = max(1, math.ceil(chapter_count * 0.3))
     midpoint_start = max(2, math.ceil(run.requested_chapters * 0.4))
     midpoint_end = max(midpoint_start, math.floor(run.requested_chapters * 0.7))
     midpoint_rule = (
@@ -473,7 +474,8 @@ def build_outline_chunk_messages(
                 f"- return exactly chapters {start_chapter} through {end_chapter}, no missing chapters and no extra chapters\n"
                 "- continue the prior outline instead of repeating its inciting incident, discovery, midpoint, or climax\n"
                 "- each chapter must change the external situation and at least one character state\n"
-                "- use setback or reversal often enough that the full book does not become a clean-win chain\n"
+                f"- at least {minimum_local_setbacks} chapters in this chunk must have outcome_type set to setback or reversal\n"
+                "- distribute those setbacks/reversals across the chunk instead of clustering them all at the end\n"
                 f"{midpoint_rule}"
                 "- every local block of 4 chapters should include at least 1 chapter_mode of breather or aftermath when possible\n"
                 "- do not repeat any chapter_mode used by either of the previous 2 accepted chapters\n"
@@ -848,6 +850,62 @@ def build_chapter_revision_messages(
     ]
 
 
+def build_chapter_expansion_messages(
+    project: Project,
+    run: GenerationRun,
+    chapter: ChapterDraft,
+    outline_entry: StructuredOutlineEntry | dict[str, Any],
+    story_bible: StoryBible | dict[str, Any],
+    continuity_ledger: ContinuityLedger | dict[str, Any],
+    plan: ChapterPlan | dict[str, Any],
+) -> list[dict[str, str]]:
+    entry = outline_entry if isinstance(outline_entry, dict) else outline_entry.model_dump()
+    bible = story_bible if isinstance(story_bible, dict) else story_bible.model_dump()
+    ledger = continuity_ledger if isinstance(continuity_ledger, dict) else continuity_ledger.model_dump()
+    chapter_plan = plan if isinstance(plan, dict) else plan.model_dump()
+    profile = _story_bible_genre_profile(bible)
+    style_profile = bible.get("style_profile") or {}
+    current_word_count = len((chapter.content or "").split())
+    target_floor = max(run.min_words_per_chapter, current_word_count + 250)
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You expand under-length fiction chapters into fuller finished scenes. "
+                "Return the complete revised chapter prose only, with no heading, markdown, or notes."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Expand chapter {chapter.chapter_number} of '{project.title}' from {current_word_count} words "
+                f"to at least {target_floor} words, staying within the target range "
+                f"{run.min_words_per_chapter}-{run.max_words_per_chapter} when possible.\n\n"
+                f"Story bible:\n{json.dumps(bible, indent=2)}\n\n"
+                f"Selected genre profile:\n{_genre_profile_block(profile)}\n\n"
+                f"Prose style profile:\n{json.dumps(style_profile, indent=2)}\n\n"
+                f"Continuity ledger:\n{json.dumps(ledger, indent=2)}\n\n"
+                f"Chapter outline:\n{json.dumps(entry, indent=2)}\n\n"
+                f"Chapter plan:\n{json.dumps(chapter_plan, indent=2)}\n\n"
+                f"Current under-length chapter:\n{chapter.content or ''}\n\n"
+                "Expansion rules:\n"
+                "- return the full expanded chapter, not only added passages\n"
+                "- preserve the existing plot outcome, continuity facts, ending_state, and concrete ending hook\n"
+                "- add missing dramatized scene work: action, dialogue, sensory detail, emotional reaction, civilian texture, and consequence\n"
+                "- do not pad with recap, repeated exposition, abstract reflection, or summary of what will happen later\n"
+                "- make the chapter_plan.story_turn more visible through decisions, rejected alternatives, and fallout\n"
+                "- deepen side-character agency and ideological pressure through concrete behavior or dialogue\n"
+                "- preserve names, roles, systems, locations, and the canon registry\n"
+                "- obey the prose style profile and profile-specific drafting focus: "
+                + "; ".join(profile.drafting_focus)
+                + "\n"
+                "- keep the final beat concrete and consistent with the chapter's ending hook\n\n"
+                "Return complete expanded chapter prose only."
+            ),
+        },
+    ]
+
+
 def build_summary_messages(chapter: ChapterDraft, outline_entry: StructuredOutlineEntry | dict[str, Any]) -> list[dict[str, str]]:
     entry = outline_entry if isinstance(outline_entry, dict) else outline_entry.model_dump()
     return [
@@ -1182,6 +1240,9 @@ def build_chapter_edit_messages(
                 f"Current continuity ledger:\n{json.dumps(ledger, indent=2)}\n\n"
                 f"Manuscript QA editing context:\n{json.dumps(_qa_editing_context(qa_report), indent=2)}\n\n"
                 f"Developmental action for this chapter:\n{json.dumps(developmental_action, indent=2)}\n\n"
+                f"Current word count: {chapter.word_count}. Target word range: "
+                f"{chapter.run.min_words_per_chapter if chapter.run else 'configured minimum'}-"
+                f"{chapter.run.max_words_per_chapter if chapter.run else 'configured maximum'}.\n\n"
                 f"Current chapter prose:\n{chapter.content or ''}\n\n"
                 "Final editing instructions:\n"
                 "- preserve the same plot events, order of events, POV, named entities, relationship state, and continuity outcome\n"
@@ -1193,7 +1254,8 @@ def build_chapter_edit_messages(
                 "- sharpen side-character agency without changing the continuity outcome\n"
                 "- keep the ending concrete: a visible action, irreversible choice, reveal, reversal, or state change, not a thesis about what comes next\n"
                 "- honor the style profile and selected genre profile without imitating any protected style reference\n"
-                "- keep roughly the same length unless trimming improves repetition or clarity\n\n"
+                "- preserve or gently increase the chapter length when it is near the lower target; do not compress it below the configured minimum word count\n"
+                "- keep roughly the same length unless trimming improves repetition or clarity and the chapter remains within the target range\n\n"
                 "Return final edited chapter prose only."
             ),
         },

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -192,6 +192,28 @@ def _valid_outline_chunk_responses(total_chapters: int = 64) -> list[str]:
     ]
 
 
+def _smooth_outline_entry(index: int, total_chapters: int) -> dict[str, object]:
+    entry = _valid_outline_entry(index, total_chapters)
+    entry["title"] = f"Moon Canal Turn {index}"
+    entry["objective"] = f"Iris follows a specific generated route beat {index}."
+    entry["outcome_type"] = "compromise"
+    return entry
+
+
+def _smooth_outline_chunk_responses(total_chapters: int = 32) -> list[str]:
+    return [
+        json.dumps(
+            {
+                "chapters": [
+                    _smooth_outline_entry(index, total_chapters)
+                    for index in range(start_chapter, min(total_chapters, start_chapter + 7) + 1)
+                ]
+            }
+        )
+        for start_chapter in range(1, total_chapters + 1, 8)
+    ]
+
+
 def _story_turn_payload(index: int) -> dict[str, object]:
     turns: dict[int, dict[str, object]] = {
         1: {
@@ -437,7 +459,15 @@ class FakeOllamaClient:
         return response
 
 
-def _create_project(session, *, requested_chapters: int = 2, approved_canon: list[dict] | None = None):
+def _create_project(
+    session,
+    *,
+    requested_chapters: int = 2,
+    desired_word_count: int = 2000,
+    min_words_per_chapter: int = 900,
+    max_words_per_chapter: int = 1200,
+    approved_canon: list[dict] | None = None,
+):
     story_brief = {
         "setting": "A failing memory-city",
         "tone": "Tense luminous sci-fi",
@@ -452,10 +482,10 @@ def _create_project(session, *, requested_chapters: int = 2, approved_canon: lis
         ProjectCreate(
             title="The Glass Orchard",
             premise="A disgraced archivist finds a living map under a failing city.",
-            desired_word_count=2000,
+            desired_word_count=desired_word_count,
             requested_chapters=requested_chapters,
-            min_words_per_chapter=900,
-            max_words_per_chapter=1200,
+            min_words_per_chapter=min_words_per_chapter,
+            max_words_per_chapter=max_words_per_chapter,
             preferred_model="test-model",
             story_brief=story_brief,
         ),
@@ -662,6 +692,69 @@ def test_continuity_fallback_completes_run_when_continuity_provider_fails(config
         assert refreshed.chapters[0].continuity_update
 
 
+def test_under_length_chapter_expands_before_critique(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    short_draft = "Iris found the map. Tarin told her the corridor was closing."
+    expanded_draft = " ".join(["Iris widened the scene with concrete cost and dialogue."] * 220)
+    expanded_revision = " ".join(["Tarin challenged Iris while the living map exacted a visible cost."] * 220)
+    final_edit = " ".join(["Iris kept the expanded scene polished and specific."] * 220)
+
+    with session_factory() as session:
+        project = _create_project(
+            session,
+            requested_chapters=1,
+            desired_word_count=1800,
+            min_words_per_chapter=1500,
+            max_words_per_chapter=2200,
+        )
+        run = create_run(
+            session,
+            project,
+            RunCreate(
+                project_id=project.id,
+                model_name="test-model",
+                pause_after_outline=False,
+                developmental_rewrite_enabled=False,
+            ),
+        )
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient(
+                [
+                    _story_bible_json(),
+                    _outline_json(1),
+                    _plan_json(1),
+                    short_draft,
+                    expanded_draft,
+                    _critique_json(revision_required=True),
+                    expanded_revision,
+                    _critique_json(revision_required=False),
+                    "Iris expands the route choice into a concrete cost.",
+                    _continuity_json(1),
+                    _qa_report_json(),
+                    final_edit,
+                    _qa_report_json(),
+                ]
+            ),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.COMPLETED
+        chapter = refreshed.chapters[0]
+        assert chapter.word_count >= refreshed.min_words_per_chapter
+        assert chapter.content == final_edit
+        assert any(event.event_type == "chapter_expansion_completed" for event in refreshed.events)
+        attempts = list_stage_attempts(session, refreshed.id)
+        assert any(attempt.stage == "chapter_expansion" and attempt.status == "success" for attempt in attempts)
+
+
 def test_large_run_generates_outline_in_chunks_and_pauses(configured_environment) -> None:
     settings = get_settings()
     session_factory = get_session_factory()
@@ -687,6 +780,66 @@ def test_large_run_generates_outline_in_chunks_and_pauses(configured_environment
         assert [entry["chapter_number"] for entry in refreshed.outline] == list(range(1, 65))
         assert len(refreshed.chapters) == 64
         assert sum(event.event_type == "outline_chunk_completed" for event in refreshed.events) == 8
+
+
+def test_32_chapter_run_generates_outline_in_chunks_and_pauses(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=32)
+        run = create_run(session, project, RunCreate(project_id=project.id, model_name="test-model"))
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient([_story_bible_json(), *_valid_outline_chunk_responses(total_chapters=32)]),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.AWAITING_APPROVAL
+        assert refreshed.current_step == "outline_review"
+        assert refreshed.outline is not None
+        assert len(refreshed.outline) == 32
+        assert [entry["chapter_number"] for entry in refreshed.outline] == list(range(1, 33))
+        assert len(refreshed.chapters) == 32
+        assert sum(event.event_type == "outline_chunk_completed" for event in refreshed.events) == 4
+        attempts = list_stage_attempts(session, refreshed.id)
+        assert {attempt.stage for attempt in attempts} == {"story_bible", "outline_chunk"}
+
+
+def test_chunked_outline_validation_repair_preserves_generated_chapters(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=32)
+        run = create_run(session, project, RunCreate(project_id=project.id, model_name="test-model"))
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(
+            session,
+            run,
+            settings,
+            FakeOllamaClient([_story_bible_json(), *_smooth_outline_chunk_responses(total_chapters=32)]),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.AWAITING_APPROVAL
+        assert refreshed.outline is not None
+        assert refreshed.outline[0]["title"] == "Moon Canal Turn 1"
+        assert refreshed.outline[15]["title"] == "Moon Canal Turn 16"
+        assert sum(
+            1
+            for entry in refreshed.outline
+            if entry["outcome_type"].lower() in {"setback", "reversal"}
+        ) >= 10
+        assert any(event.event_type == "outline_validation_repaired" for event in refreshed.events)
+        assert not any(event.event_type == "outline_validation_fallback" for event in refreshed.events)
 
 
 def test_large_outline_chunk_fallback_prevents_short_outline_failure(configured_environment) -> None:

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -321,6 +321,17 @@ def test_project_detail_preflight_warns_for_64_chapter_runs(client, monkeypatch)
     assert "396 minimum" in response.text
 
 
+def test_project_detail_preflight_chunks_32_chapter_runs(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
+    project_id = seed_project(requested_chapters=32, desired_word_count=32000)
+
+    response = client.get(f"/projects/{project_id}")
+
+    assert response.status_code == 200
+    assert "32 chapters will use 4 outline chunks" in response.text
+    assert "200 minimum" in response.text
+
+
 def test_notice_tone_renders_warning_notice_class(client, monkeypatch) -> None:
     monkeypatch.setattr(OllamaClient, "health", lambda self, default_model: reachable_status(default_model))
 


### PR DESCRIPTION
## Summary
- chunk 32-chapter outlines instead of sending one monolithic outline request
- add chapter expansion passes so under-length drafts/revisions are expanded before continuity checkpoints
- salvage complete generated outlines that fail full-book pacing validation instead of replacing them with generic deterministic outlines
- surface chapter expansion and 32-chapter chunking in the UI/preflight

## Test Plan
- docker compose exec -T web python -m pytest tests/test_pipeline.py::test_32_chapter_run_generates_outline_in_chunks_and_pauses tests/test_pipeline.py::test_chunked_outline_validation_repair_preserves_generated_chapters tests/test_pipeline.py::test_under_length_chapter_expands_before_critique
- docker compose exec -T web python -m pytest (136 passed)
- docker compose up --build -d web worker
- GET /api/health