### PR TITLE
[codex] Add publication-quality generation profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Novel Generator
 
-Novel Generator is a self-hosted, Ollama-first writing studio for long-form fiction. It lets a single author create reusable projects, queue background generation runs, stream progress in the browser, persist chapter-by-chapter state, and export finished manuscripts as Markdown and DOCX.
+Novel Generator is a self-hosted, Ollama-first writing studio for long-form fiction. It lets a single author create reusable book projects, queue background generation runs, inspect long-run progress in the browser, recover from model or worker failures, and export complete manuscripts as Markdown and DOCX layout helpers.
+
+The product is built around one practical goal: get to a complete book draft, then make the draft increasingly reviewable, editable, and polished without losing the run history that produced it.
 
 ![Updated product preview](docs/screenshots/dashboard-preview.svg)
 
@@ -10,9 +12,13 @@ Novel Generator is a self-hosted, Ollama-first writing studio for long-form fict
 - SQLite-first persistence with Alembic migrations
 - Background worker process for queued generation runs
 - Ollama provider integration with model discovery and health checks
-- Chapter-level checkpointing and regeneration from any chapter onward
-- Standard developmental planning plus a final chapter edit pass before export
-- Markdown and DOCX artifact export
+- Provider routing, per-stage attempt tracking, stale-worker recovery, and failed-run resume
+- Run confidence views for stage, event, chapter, word, provider, and artifact progress
+- Outline review workspace for long outlines, including 32- and 64-chapter projects
+- Chapter-level checkpointing, in-place resume, and regeneration from any chapter onward
+- Draft, balanced, strict, and publication quality profiles
+- Standard developmental planning, targeted revision waves, final chapter editing, and optional publication-mode humanization/compression passes
+- Markdown and DOCX manuscript exports plus publication layout helpers with required front matter
 - Docker Compose setup for self-hosting
 
 ## Quick Start
@@ -32,6 +38,32 @@ If you want Ollama in the same compose stack, enable the optional profile and po
 ```bash
 docker compose --profile ollama up --build
 ```
+
+## First Run
+
+1. Open the dashboard and create a project with a premise, target word count, chapter count, genre, and model.
+2. Confirm the provider health check before queueing. For high chapter counts, use outline approval so you can review the book shape before drafting starts.
+3. Choose a quality profile:
+   - `draft`: fastest route to a complete manuscript. Best for exploring a premise.
+   - `balanced`: default behavior. Standard QA, developmental planning, targeted revisions, and final chapter editing.
+   - `strict`: stronger revision thresholds for a more conservative editorial pass.
+   - `publication`: highest-cost path. Forces outline approval, developmental rewrite, character humanization, prose compression, final editing, and a final publication-readiness QA gate.
+4. Let the worker run. The run page shows current stage, last event, provider route, chapter progress, word progress, attempts, artifacts, and recovery guidance.
+5. If a run fails, use resume from checkpoint when available. Already completed chapters, summaries, continuity updates, attempts, and events are preserved.
+6. Export only after reviewing the final QA report. Publication exports are layout helpers and require real front matter instead of placeholders.
+
+## Quality Profiles
+
+The profiles trade speed for editorial pressure.
+
+| Profile | Best for | Behavior |
+| --- | --- | --- |
+| `draft` | Fast exploration | Defers non-blocking polish so long runs reach a complete manuscript sooner. |
+| `balanced` | Normal complete drafts | Uses the standard chapter QA, developmental rewrite planning, targeted revision waves, and final edit pass. |
+| `strict` | More cautious drafts | Tightens revision triggers and enables developmental rewrite by default. |
+| `publication` | Serious editorial review | Drafts long, then cuts. Adds character-private-life requirements, scene-variety rules, motif budgets, humanization revisions, compression, final editing, and a readiness score. |
+
+Publication mode is intentionally expensive. It is designed to address generated-manuscript weaknesses such as repeated atmosphere, looped crisis structure, allegorical characters, over-explained prose, thin ordinary human friction, and misleading publication exports. If the final readiness gate still finds major risk, the run completes as a reviewable manuscript labeled as needing editorial revision instead of claiming to be publication-ready.
 
 ## Model Benchmarks
 
@@ -99,7 +131,7 @@ On Windows PowerShell, activate the environment with `.venv\Scripts\Activate.ps1
 - `GET /api/runs/{id}/events`
 - `GET /api/artifacts/{id}/download`
 
-## Architecture
+## How Generation Works
 
 - `src/novel_generator/routers`: HTTP routes for the API and UI
 - `src/novel_generator/services`: Ollama integration, prompts, pipeline, exports, and worker logic
@@ -108,16 +140,30 @@ On Windows PowerShell, activate the environment with `.venv\Scripts\Activate.ps1
 
 The generation pipeline is designed to finish a complete book package, even for 32- and 64-chapter runs:
 
-1. Create or reuse an outline.
-2. Plan a chapter.
-3. Draft the chapter.
-4. Summarize it for continuity memory.
-5. Persist progress after each step.
+1. Create or reuse a story bible and outline.
+2. Pause for outline review when requested, or automatically for publication runs.
+3. Plan each chapter, draft prose, critique the chapter, revise when profile thresholds require it, summarize for continuity, and update the continuity ledger.
+4. Persist progress after each stage so the run can resume from checkpoints.
+5. Record safe model-call attempts with provider, model, stage, timing, status, output length, and error metadata.
 6. Run manuscript QA after the full draft is assembled.
-7. Build a standard developmental rewrite plan and revised-outline report.
+7. Build a developmental rewrite plan and revised-outline report.
 8. Apply targeted developmental revision waves to chapters marked for structural action.
-9. Line-edit each saved chapter for polish while preserving approved story state.
-10. Run final manuscript QA, then export Markdown, DOCX, and QA artifacts.
+9. For publication runs, supplement weak rewrite plans with deterministic QA findings, then run character humanization and prose compression waves.
+10. Line-edit each saved chapter for clarity, sentence rhythm, transitions, and concrete on-page consequences.
+11. Run final manuscript QA. Publication runs also receive scored readiness notes for concept/world, atmosphere, thematic ambition, plot coherence, character depth, prose control, repetition, and publication readiness.
+12. Export Markdown, DOCX, QA reports, revised outlines, and publication layout helpers as artifacts.
+
+## Publication Exports
+
+Publication export profiles are layout helpers, not a promise that the manuscript is ready to sell. The export form requires:
+
+- Author name
+- Copyright year
+- Publisher or imprint
+- Dedication
+- Author note
+
+ISBN is optional. If ISBN is blank, the ISBN line is omitted. Bracketed placeholder text such as `[Author Name]` is rejected so generated exports cannot silently ship placeholder front matter.
 
 ## Self-Hosting Notes
 

--- a/src/novel_generator/repositories.py
+++ b/src/novel_generator/repositories.py
@@ -187,7 +187,9 @@ def create_run(session: Session, project: Project, payload: RunCreate) -> Genera
     max_words_per_chapter = payload.max_words_per_chapter or project.max_words_per_chapter
     task_routing = _normalized_task_routing(payload.task_routing) if payload.task_routing is not None else deepcopy(project.task_routing or {})
     quality_profile = payload.quality_profile or "balanced"
-    developmental_rewrite_enabled = payload.developmental_rewrite_enabled or quality_profile == "strict"
+    is_publication_profile = quality_profile == "publication"
+    developmental_rewrite_enabled = payload.developmental_rewrite_enabled or quality_profile in {"strict", "publication"}
+    pause_after_outline = True if is_publication_profile else payload.pause_after_outline
 
     if not provider_name:
         raise ValueError("A provider name is required.")
@@ -205,7 +207,7 @@ def create_run(session: Session, project: Project, payload: RunCreate) -> Genera
         min_words_per_chapter=min_words_per_chapter,
         max_words_per_chapter=max_words_per_chapter,
         pipeline_version=2,
-        pause_after_outline=payload.pause_after_outline,
+        pause_after_outline=pause_after_outline,
         developmental_rewrite_enabled=developmental_rewrite_enabled,
         quality_profile=quality_profile,
         task_routing=task_routing,

--- a/src/novel_generator/routers/ui.py
+++ b/src/novel_generator/routers/ui.py
@@ -130,11 +130,32 @@ RUN_STAGES = [
         "result": "Targeted chapters should gain safer before/after revision events while unchanged chapters pass through to final edit.",
     },
     {
+        "id": "chapter_humanization",
+        "label": "Humanize chapter",
+        "description": "Adding ordinary human friction and character texture for publication mode.",
+        "why": "The worker is reducing allegorical or discipline-only characterization while preserving the chapter's canon outcome.",
+        "result": "Targeted chapters should gain more private wants, subtext, and believable interpersonal pressure.",
+    },
+    {
+        "id": "chapter_compression",
+        "label": "Compress prose",
+        "description": "Cutting repeated motifs, filler explanation, and generated-feeling density.",
+        "why": "Publication mode drafts long enough to leave material for a later compression pass, then trims repeated atmosphere and over-explanation.",
+        "result": "Targeted chapters should move closer to the final word target with cleaner prose.",
+    },
+    {
         "id": "chapter_edit",
         "label": "Final edit",
         "description": "Polishing saved chapter prose before final QA and export.",
         "why": "The worker is line-editing each chapter for clarity, rhythm, concrete sensory detail, and cleaner transitions while preserving the story state.",
         "result": "Chapter text and word counts should update without changing the approved outline or continuity checkpoints.",
+    },
+    {
+        "id": "publication_readiness",
+        "label": "Readiness QA",
+        "description": "Scoring the manuscript against publication-readiness criteria.",
+        "why": "Publication mode distinguishes a reviewable manuscript from one that is actually ready for publication layout.",
+        "result": "The final QA report should show publication-readiness scores and whether more editorial work is needed.",
     },
     {
         "id": "export",
@@ -212,6 +233,12 @@ QUALITY_PROFILE_DEFS = [
         "summary": "Most editorial scrutiny",
         "description": "Use tighter revision thresholds with standard developmental planning and the final edit pass.",
     },
+    {
+        "value": "publication",
+        "label": "Publication",
+        "summary": "Highest-cost editorial path",
+        "description": "Draft long, force developmental actions, humanize characters, compress repeated prose, run final readiness QA, and require outline approval.",
+    },
 ]
 QUALITY_PROFILE_LOOKUP = {item["value"]: item for item in QUALITY_PROFILE_DEFS}
 RUN_STAGE_LOOKUP = {stage["id"]: stage for stage in RUN_STAGES}
@@ -227,7 +254,10 @@ RUN_STAGE_PROGRESS_ORDER = [
     "manuscript_qa",
     "developmental_rewrite",
     "developmental_revision",
+    "chapter_humanization",
+    "chapter_compression",
     "chapter_edit",
+    "publication_readiness",
     "export",
     "completed",
 ]
@@ -1424,7 +1454,7 @@ def _run_preflight_context(
     target_word_count = _positive_int(values.get("target_word_count"), 1)
     pause_after_outline = bool(values.get("pause_after_outline", True))
     profile = _quality_profile_context(values.get("quality_profile"))
-    developmental_rewrite_enabled = bool(values.get("developmental_rewrite_enabled")) or profile["value"] == "strict"
+    developmental_rewrite_enabled = bool(values.get("developmental_rewrite_enabled")) or profile["value"] in {"strict", "publication"}
     task_routing = _task_routing_payload(values)
     route_disclosure = _route_privacy_summary(provider_name, model_name, task_routing)
     config = configs_by_name.get(provider_name)
@@ -3436,6 +3466,13 @@ def publication_export_ui(
     run_id: str,
     profile_id: str = Form(...),
     include_ai_disclosure: str | None = Form(None),
+    author_name: str = Form(""),
+    copyright_year: str = Form(""),
+    publisher: str = Form(""),
+    dedication: str = Form(""),
+    author_note: str = Form(""),
+    isbn: str = Form(""),
+    ai_disclosure: str = Form(""),
     db: Session = Depends(get_db),
     settings: Settings = Depends(get_app_settings),
 ):
@@ -3469,6 +3506,15 @@ def publication_export_ui(
             chapters,
             profile_id,
             include_ai_disclosure=_coerce_checkbox(include_ai_disclosure),
+            front_matter={
+                "author_name": author_name,
+                "copyright_year": copyright_year,
+                "publisher": publisher,
+                "dedication": dedication,
+                "author_note": author_note,
+                "isbn": isbn,
+                "ai_disclosure": ai_disclosure,
+            },
         )
     except ValueError as exc:
         return _redirect(f"/runs/{run.id}", message=str(exc), message_tone="warning")

--- a/src/novel_generator/schemas.py
+++ b/src/novel_generator/schemas.py
@@ -10,7 +10,7 @@ from .models import ChapterStatus, RunStatus
 from .services.genre_profiles import DEFAULT_GENRE_PROFILE, GENRE_PROFILES
 
 
-QUALITY_PROFILE_VALUES = {"draft", "balanced", "strict"}
+QUALITY_PROFILE_VALUES = {"draft", "balanced", "strict", "publication"}
 
 ALLOWED_CHAPTER_MODES = {
     "investigation",
@@ -94,7 +94,7 @@ def _validate_genre_profile(value: Any) -> str:
 def _validate_quality_profile(value: Any) -> str:
     key = str(value or "balanced").strip().lower().replace("-", "_").replace(" ", "_")
     if key not in QUALITY_PROFILE_VALUES:
-        raise ValueError("Choose draft, balanced, or strict.")
+        raise ValueError("Choose draft, balanced, strict, or publication.")
     return key
 
 
@@ -612,6 +612,9 @@ class ManuscriptQaReport(BaseModel):
     genre_contract_notes: list[str] = Field(default_factory=list)
     continuity_bible_findings: list[str] = Field(default_factory=list)
     continuity_bible_table: list[ContinuityBibleRow] = Field(default_factory=list)
+    publication_readiness_scores: dict[str, int] = Field(default_factory=dict)
+    publication_readiness_label: str = ""
+    publication_readiness_summary: str = ""
 
     @field_validator("overall_verdict", mode="before")
     @classmethod
@@ -674,6 +677,30 @@ class ManuscriptQaReport(BaseModel):
                     rows.append({"item_type": "note", "name": rendered, "notes": rendered})
             return rows
         return []
+
+    @field_validator("publication_readiness_scores", mode="before")
+    @classmethod
+    def validate_publication_readiness_scores(cls, value: Any) -> dict[str, int]:
+        if not isinstance(value, dict):
+            return {}
+        scores: dict[str, int] = {}
+        for key, item in value.items():
+            name = str(key).strip()
+            if not name:
+                continue
+            try:
+                numeric = int(round(float(item)))
+            except (TypeError, ValueError):
+                continue
+            scores[name] = max(0, min(10, numeric))
+        return scores
+
+    @field_validator("publication_readiness_label", "publication_readiness_summary", mode="before")
+    @classmethod
+    def validate_publication_readiness_strings(cls, value: Any) -> str:
+        if value is None:
+            return ""
+        return str(value).strip()
 
 
 class DevelopmentalChapterAction(BaseModel):

--- a/src/novel_generator/services/editorial.py
+++ b/src/novel_generator/services/editorial.py
@@ -29,6 +29,45 @@ STOCK_PHRASES = [
     "mara stared",
 ]
 
+PUBLICATION_MOTIFS = {
+    "brine",
+    "copper",
+    "damp",
+    "guilt",
+    "memory",
+    "pressure",
+    "resonance",
+    "structural",
+    "truth",
+    "wet stone",
+}
+
+GENERATED_ABSTRACT_NOUNS = {
+    "agency",
+    "collapse",
+    "consequence",
+    "control",
+    "fracture",
+    "memory",
+    "pressure",
+    "resonance",
+    "stability",
+    "structure",
+    "truth",
+    "vulnerability",
+}
+
+DISCIPLINE_DIALOGUE_TERMS = {
+    "calculation",
+    "cartography",
+    "engineering",
+    "infrastructure",
+    "materials",
+    "procedure",
+    "system",
+    "theory",
+}
+
 BREATHER_MODES = {"breather", "aftermath"}
 
 TECHNICAL_SCENE_MODES = {"systems_crisis", "technical_operation"}
@@ -703,6 +742,96 @@ def _technical_fatigue_hits(text: str) -> Counter[str]:
         if count:
             hits[label] = count
     return hits
+
+
+def _word_count(text: str) -> int:
+    return len(re.findall(r"[A-Za-z][A-Za-z'-]*", text))
+
+
+def _motif_counts(text: str) -> Counter[str]:
+    lowered = text.lower()
+    counts: Counter[str] = Counter()
+    for motif in PUBLICATION_MOTIFS:
+        if " " in motif:
+            counts[motif] = lowered.count(motif)
+        else:
+            counts[motif] = len(re.findall(rf"\b{re.escape(motif)}\b", lowered))
+    return Counter({motif: count for motif, count in counts.items() if count})
+
+
+def _publication_motif_findings(chapters: list[ChapterDraft]) -> list[str]:
+    findings: list[str] = []
+    manuscript_text = "\n\n".join(chapter.content or "" for chapter in chapters)
+    total_words = max(1, _word_count(manuscript_text))
+    counts = _motif_counts(manuscript_text)
+    for motif, count in counts.most_common():
+        per_10k = count / total_words * 10000
+        if count >= 8 and per_10k >= 7:
+            findings.append(
+                f"Publication motif overuse: '{motif}' appears {count} times ({per_10k:.1f} per 10k words)."
+            )
+
+    for chapter in chapters:
+        chapter_counts = _motif_counts(chapter.content or "")
+        dense = [motif for motif, count in chapter_counts.items() if count >= 3]
+        if dense:
+            findings.append(
+                f"Chapter {chapter.chapter_number} repeats atmospheric motif(s) too often: "
+                + ", ".join(sorted(dense)[:5])
+                + "."
+            )
+    return findings
+
+
+def _chapter_opening_similarity_findings(chapters: list[ChapterDraft]) -> list[str]:
+    findings: list[str] = []
+    opening_terms = []
+    for chapter in chapters:
+        paragraphs = [paragraph.strip() for paragraph in re.split(r"\n\s*\n+", chapter.content or "") if paragraph.strip()]
+        if not paragraphs:
+            continue
+        terms = set(sorted(_meaningful_terms(paragraphs[0]))[:40])
+        if terms:
+            opening_terms.append((chapter.chapter_number, terms))
+
+    for index, (left_number, left_terms) in enumerate(opening_terms):
+        for right_number, right_terms in opening_terms[index + 1 :]:
+            overlap = len(left_terms & right_terms) / max(1, min(len(left_terms), len(right_terms)))
+            if overlap >= 0.62:
+                findings.append(
+                    f"Chapters {left_number} and {right_number} have highly similar opening texture; vary the entry image and dramatic mode."
+                )
+                if len(findings) >= 6:
+                    return findings
+    return findings
+
+
+def _generated_abstract_cluster_findings(chapters: list[ChapterDraft]) -> list[str]:
+    findings: list[str] = []
+    for chapter in chapters:
+        text = (chapter.content or "").lower()
+        words = max(1, _word_count(text))
+        hits = sum(len(re.findall(rf"\b{re.escape(term)}\b", text)) for term in GENERATED_ABSTRACT_NOUNS)
+        if hits >= 18 and hits / words * 1000 >= 8:
+            findings.append(
+                f"Chapter {chapter.chapter_number} has a generated-feeling abstract noun cluster ({hits} theme/system terms)."
+            )
+    return findings
+
+
+def _dialogue_discipline_findings(chapters: list[ChapterDraft]) -> list[str]:
+    findings: list[str] = []
+    for chapter in chapters:
+        dialogue = " ".join(re.findall(r'"([^"]+)"', chapter.content or ""))
+        if not dialogue:
+            continue
+        lowered = dialogue.lower()
+        hits = [term for term in DISCIPLINE_DIALOGUE_TERMS if re.search(rf"\b{re.escape(term)}\b", lowered)]
+        if len(hits) >= 4:
+            findings.append(
+                f"Chapter {chapter.chapter_number} dialogue leans on discipline labels ({', '.join(sorted(hits)[:5])}) instead of private human friction."
+            )
+    return findings
 
 
 def _pattern_phrases(text: str, patterns: list[str], limit: int = 3) -> list[str]:
@@ -2015,6 +2144,10 @@ def lint_manuscript(chapters: list[ChapterDraft]) -> list[str]:
         count = manuscript_text.count(phrase)
         if count >= 4:
             findings.append(f"Repeated stock phrase '{phrase}' appears {count} times.")
+    findings.extend(_publication_motif_findings(chapters))
+    findings.extend(_chapter_opening_similarity_findings(chapters))
+    findings.extend(_generated_abstract_cluster_findings(chapters))
+    findings.extend(_dialogue_discipline_findings(chapters))
 
     for chapter in chapters:
         for hit in _meta_language_hits(chapter.content or ""):
@@ -2058,6 +2191,7 @@ def manuscript_quality_notes(
         "easy_win_warnings": [],
         "proper_noun_continuity_findings": [],
         "side_character_agency_notes": [],
+        "repetition_risks": [],
         "atmospheric_repetition_findings": [],
         "emotional_pacing_notes": [],
         "ideology_consistency_findings": [],
@@ -2227,6 +2361,12 @@ def manuscript_quality_notes(
             + "."
         )
 
+    notes["atmospheric_repetition_findings"].extend(_publication_motif_findings(sorted_chapters))
+    notes["atmospheric_repetition_findings"].extend(_chapter_opening_similarity_findings(sorted_chapters))
+    notes["repetition_risks"] = notes.get("repetition_risks", [])
+    notes["repetition_risks"].extend(_generated_abstract_cluster_findings(sorted_chapters))
+    notes["side_character_agency_notes"].extend(_dialogue_discipline_findings(sorted_chapters))
+
     if bible:
         side_decision_counts: Counter[str] = Counter()
         for chapter in chapters:
@@ -2277,6 +2417,7 @@ def manuscript_quality_notes(
     notes["proper_noun_continuity_findings"] = list(dict.fromkeys(notes["proper_noun_continuity_findings"]))
     notes["side_character_agency_notes"] = list(dict.fromkeys(notes["side_character_agency_notes"]))
     notes["atmospheric_repetition_findings"] = list(dict.fromkeys(notes["atmospheric_repetition_findings"]))
+    notes["repetition_risks"] = list(dict.fromkeys(notes.get("repetition_risks", [])))
     notes["emotional_pacing_notes"] = list(dict.fromkeys(notes["emotional_pacing_notes"]))
     notes["ideology_consistency_findings"] = list(dict.fromkeys(notes["ideology_consistency_findings"]))
     notes["civilian_texture_findings"] = list(dict.fromkeys(notes["civilian_texture_findings"]))
@@ -2296,10 +2437,36 @@ def render_qa_report_markdown(report: ManuscriptQaReport) -> str:
         "",
         f"**Overall verdict:** {report.overall_verdict}",
         "",
-        "## Strengths",
-        "",
-        *([f"- {item}" for item in report.strengths] or ["- No strengths recorded."]),
-        "",
+    ]
+    if report.publication_readiness_scores or report.publication_readiness_label or report.publication_readiness_summary:
+        sections.extend(
+            [
+                "## Publication Readiness",
+                "",
+                f"**Status:** {report.publication_readiness_label or 'Not assessed'}",
+                "",
+                report.publication_readiness_summary or "No publication-readiness summary recorded.",
+                "",
+            ]
+        )
+        if report.publication_readiness_scores:
+            sections.extend(
+                [
+                    "| Area | Score |",
+                    "| --- | ---: |",
+                    *[
+                        f"| {label.replace('_', ' ').title()} | {score}/10 |"
+                        for label, score in report.publication_readiness_scores.items()
+                    ],
+                    "",
+                ]
+            )
+    sections.extend(
+        [
+            "## Strengths",
+            "",
+            *([f"- {item}" for item in report.strengths] or ["- No strengths recorded."]),
+            "",
         "## Warnings",
         "",
         *([f"- {item}" for item in report.warnings] or ["- No major warnings recorded."]),
@@ -2380,7 +2547,8 @@ def render_qa_report_markdown(report: ManuscriptQaReport) -> str:
         "",
         *([f"- {item}" for item in report.lint_findings] or ["- No deterministic lint findings recorded."]),
         "",
-    ]
+        ]
+    )
     return "\n".join(sections).strip() + "\n"
 
 

--- a/src/novel_generator/services/exports.py
+++ b/src/novel_generator/services/exports.py
@@ -31,6 +31,17 @@ class ExportProfile:
     publication_ready: bool = False
 
 
+@dataclass(frozen=True)
+class PublicationFrontMatter:
+    author_name: str
+    copyright_year: str
+    publisher: str
+    dedication: str
+    author_note: str
+    isbn: str = ""
+    ai_disclosure: str = ""
+
+
 EXPORT_PROFILES = {
     "draft_markdown": ExportProfile(
         id="draft_markdown",
@@ -54,7 +65,7 @@ EXPORT_PROFILES = {
         output_format="markdown",
         filename="publication-ebook.md",
         kind="publication-markdown",
-        description="Markdown manuscript with publication front matter placeholders.",
+        description="Markdown manuscript layout helper with supplied front matter.",
         include_front_matter=True,
         publication_ready=True,
     ),
@@ -64,7 +75,7 @@ EXPORT_PROFILES = {
         output_format="docx",
         filename="publication-ebook.docx",
         kind="publication-docx",
-        description="DOCX manuscript with front matter and chapter page starts.",
+        description="DOCX manuscript layout helper with supplied front matter and chapter page starts.",
         include_front_matter=True,
         chapter_page_breaks=True,
         publication_ready=True,
@@ -75,7 +86,7 @@ EXPORT_PROFILES = {
         output_format="docx",
         filename="publication-print-5x8.docx",
         kind="publication-docx",
-        description='Print helper interior sized to 5" x 8".',
+        description='Print layout helper interior sized to 5" x 8".',
         page_width_inches=5,
         page_height_inches=8,
         inner_margin_inches=0.75,
@@ -90,7 +101,7 @@ EXPORT_PROFILES = {
         output_format="docx",
         filename="publication-print-5-5x8-5.docx",
         kind="publication-docx",
-        description='Print helper interior sized to 5.5" x 8.5".',
+        description='Print layout helper interior sized to 5.5" x 8.5".',
         page_width_inches=5.5,
         page_height_inches=8.5,
         include_front_matter=True,
@@ -103,7 +114,7 @@ EXPORT_PROFILES = {
         output_format="docx",
         filename="publication-print-6x9.docx",
         kind="publication-docx",
-        description='Print helper interior sized to 6" x 9".',
+        description='Print layout helper interior sized to 6" x 9".',
         page_width_inches=6,
         page_height_inches=9,
         top_margin_inches=0.8,
@@ -118,7 +129,7 @@ EXPORT_PROFILES = {
         output_format="docx",
         filename="publication-print-a5.docx",
         kind="publication-docx",
-        description='Print helper interior sized to A5 / 5.83" x 8.27".',
+        description='Print layout helper interior sized to A5 / 5.83" x 8.27".',
         page_width_inches=5.83,
         page_height_inches=8.27,
         include_front_matter=True,
@@ -140,6 +151,53 @@ def export_profile(profile_id: str) -> ExportProfile:
         return EXPORT_PROFILES[profile_id]
     except KeyError as exc:
         raise ValueError("Choose a supported export profile.") from exc
+
+
+def _normalize_front_matter(front_matter: PublicationFrontMatter | dict[str, str] | None) -> PublicationFrontMatter:
+    if front_matter is None:
+        raise ValueError("Publication front matter is required for publication exports.")
+    if isinstance(front_matter, PublicationFrontMatter):
+        payload = front_matter
+    elif isinstance(front_matter, dict):
+        payload = PublicationFrontMatter(
+            author_name=str(front_matter.get("author_name", "") or "").strip(),
+            copyright_year=str(front_matter.get("copyright_year", "") or "").strip(),
+            publisher=str(front_matter.get("publisher", "") or "").strip(),
+            dedication=str(front_matter.get("dedication", "") or "").strip(),
+            author_note=str(front_matter.get("author_note", "") or "").strip(),
+            isbn=str(front_matter.get("isbn", "") or "").strip(),
+            ai_disclosure=str(front_matter.get("ai_disclosure", "") or "").strip(),
+        )
+    else:
+        raise ValueError("Publication front matter must be a supported metadata object.")
+
+    required = {
+        "author name": payload.author_name,
+        "copyright year": payload.copyright_year,
+        "publisher or imprint": payload.publisher,
+        "dedication": payload.dedication,
+        "author note": payload.author_note,
+    }
+    missing = [label for label, value in required.items() if not value]
+    if missing:
+        raise ValueError("Publication front matter is missing: " + ", ".join(missing) + ".")
+
+    placeholder_values = {
+        label: value
+        for label, value in {
+            **required,
+            "isbn": payload.isbn,
+            "AI disclosure": payload.ai_disclosure,
+        }.items()
+        if re.search(r"\[[^\]]+\]", value)
+    }
+    if placeholder_values:
+        raise ValueError(
+            "Publication front matter cannot contain bracketed placeholders: "
+            + ", ".join(placeholder_values.keys())
+            + "."
+        )
+    return payload
 
 
 def export_run_artifacts(
@@ -236,10 +294,12 @@ def export_publication_artifact(
     profile_id: str,
     *,
     include_ai_disclosure: bool = False,
+    front_matter: PublicationFrontMatter | dict[str, str] | None = None,
 ) -> Artifact:
     profile = export_profile(profile_id)
     if not profile.publication_ready:
         raise ValueError("Choose a publication export profile.")
+    publication_front_matter = _normalize_front_matter(front_matter) if profile.include_front_matter else None
 
     run_dir = artifacts_dir / run.id
     run_dir.mkdir(parents=True, exist_ok=True)
@@ -247,12 +307,25 @@ def export_publication_artifact(
 
     if profile.output_format == "markdown":
         destination.write_text(
-            render_publication_markdown(project, chapters, profile, include_ai_disclosure=include_ai_disclosure),
+            render_publication_markdown(
+                project,
+                chapters,
+                profile,
+                include_ai_disclosure=include_ai_disclosure,
+                front_matter=publication_front_matter,
+            ),
             encoding="utf-8",
         )
         content_type = "text/markdown"
     elif profile.output_format == "docx":
-        render_publication_docx(project, chapters, destination, profile, include_ai_disclosure=include_ai_disclosure)
+        render_publication_docx(
+            project,
+            chapters,
+            destination,
+            profile,
+            include_ai_disclosure=include_ai_disclosure,
+            front_matter=publication_front_matter,
+        )
         content_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     else:
         raise ValueError("Unsupported export profile format.")
@@ -299,10 +372,13 @@ def render_publication_markdown(
     profile: ExportProfile,
     *,
     include_ai_disclosure: bool = False,
+    front_matter: PublicationFrontMatter | None = None,
 ) -> str:
     lines: list[str] = [f"# {project.title}", ""]
     if profile.include_front_matter:
-        lines.extend(_front_matter_markdown(project, include_ai_disclosure=include_ai_disclosure))
+        if front_matter is None:
+            raise ValueError("Publication front matter is required for publication exports.")
+        lines.extend(_front_matter_markdown(project, front_matter, include_ai_disclosure=include_ai_disclosure))
     for chapter in chapters:
         lines.extend(
             [
@@ -322,12 +398,15 @@ def render_publication_docx(
     profile: ExportProfile,
     *,
     include_ai_disclosure: bool = False,
+    front_matter: PublicationFrontMatter | None = None,
 ) -> None:
     document = Document()
     _configure_publication_document(document, profile)
-    _add_title_page(document, project)
+    _add_title_page(document, project, front_matter)
     if profile.include_front_matter:
-        _add_front_matter(document, project, include_ai_disclosure=include_ai_disclosure)
+        if front_matter is None:
+            raise ValueError("Publication front matter is required for publication exports.")
+        _add_front_matter(document, project, front_matter, include_ai_disclosure=include_ai_disclosure)
     for chapter in chapters:
         if profile.chapter_page_breaks:
             document.add_page_break()
@@ -365,7 +444,7 @@ def _configure_publication_document(document: Document, profile: ExportProfile) 
     heading.paragraph_format.first_line_indent = None
 
 
-def _add_title_page(document: Document, project: Project) -> None:
+def _add_title_page(document: Document, project: Project, front_matter: PublicationFrontMatter | None = None) -> None:
     title = document.add_paragraph()
     title.alignment = WD_ALIGN_PARAGRAPH.CENTER
     title.paragraph_format.space_before = Pt(180)
@@ -377,27 +456,35 @@ def _add_title_page(document: Document, project: Project) -> None:
     byline = document.add_paragraph()
     byline.alignment = WD_ALIGN_PARAGRAPH.CENTER
     byline.paragraph_format.first_line_indent = None
-    byline.add_run("by [Author Name]")
+    byline.add_run(f"by {front_matter.author_name if front_matter else 'Author'}")
 
 
-def _add_front_matter(document: Document, project: Project, *, include_ai_disclosure: bool) -> None:
-    _add_front_matter_page(
-        document,
-        "Copyright",
-        [
-            f"{project.title}",
-            "Copyright (c) [Year] [Author Name]. All rights reserved.",
-            "Publisher: [Publisher or imprint]",
-            "ISBN: [ISBN]",
-        ],
-    )
-    _add_front_matter_page(document, "Dedication", ["[Dedication]"])
-    _add_front_matter_page(document, "Author Note", ["[Author note]"])
+def _add_front_matter(
+    document: Document,
+    project: Project,
+    front_matter: PublicationFrontMatter,
+    *,
+    include_ai_disclosure: bool,
+) -> None:
+    copyright_lines = [
+        f"{project.title}",
+        f"Copyright (c) {front_matter.copyright_year} {front_matter.author_name}. All rights reserved.",
+        f"Publisher: {front_matter.publisher}",
+    ]
+    if front_matter.isbn:
+        copyright_lines.append(f"ISBN: {front_matter.isbn}")
+    _add_front_matter_page(document, "Copyright", copyright_lines)
+    _add_front_matter_page(document, "Dedication", [front_matter.dedication])
+    _add_front_matter_page(document, "Author Note", [front_matter.author_note])
     if include_ai_disclosure:
+        disclosure = (
+            front_matter.ai_disclosure
+            or "This manuscript was drafted and edited with AI assistance under human direction."
+        )
         _add_front_matter_page(
             document,
             "AI-Assisted Disclosure",
-            ["[Describe any AI-assisted drafting, editing, or production process you choose to disclose.]"],
+            [disclosure],
         )
 
 
@@ -413,33 +500,39 @@ def _add_front_matter_page(document: Document, heading_text: str, paragraphs: li
         paragraph.paragraph_format.first_line_indent = None
 
 
-def _front_matter_markdown(project: Project, *, include_ai_disclosure: bool) -> list[str]:
+def _front_matter_markdown(
+    project: Project,
+    front_matter: PublicationFrontMatter,
+    *,
+    include_ai_disclosure: bool,
+) -> list[str]:
     lines = [
         "## Copyright",
         "",
         f"{project.title}",
         "",
-        "Copyright (c) [Year] [Author Name]. All rights reserved.",
+        f"Copyright (c) {front_matter.copyright_year} {front_matter.author_name}. All rights reserved.",
         "",
-        "Publisher: [Publisher or imprint]",
-        "",
-        "ISBN: [ISBN]",
+        f"Publisher: {front_matter.publisher}",
         "",
         "## Dedication",
         "",
-        "[Dedication]",
+        front_matter.dedication,
         "",
         "## Author Note",
         "",
-        "[Author note]",
+        front_matter.author_note,
         "",
     ]
+    if front_matter.isbn:
+        lines[8:8] = [f"ISBN: {front_matter.isbn}", ""]
     if include_ai_disclosure:
         lines.extend(
             [
                 "## AI-Assisted Disclosure",
                 "",
-                "[Describe any AI-assisted drafting, editing, or production process you choose to disclose.]",
+                front_matter.ai_disclosure
+                or "This manuscript was drafted and edited with AI assistance under human direction.",
                 "",
             ]
         )

--- a/src/novel_generator/services/pipeline.py
+++ b/src/novel_generator/services/pipeline.py
@@ -62,6 +62,8 @@ from .prompts import (
     build_json_repair_messages,
     build_manuscript_qa_messages,
     build_outline_messages,
+    build_publication_compression_messages,
+    build_publication_humanization_messages,
     build_story_bible_messages,
     build_summary_messages,
     parse_chapter_critique,
@@ -84,6 +86,16 @@ class RunCanceled(Exception):
 
 OUTLINE_CHUNK_THRESHOLD = 32
 OUTLINE_CHUNK_SIZE = 8
+PUBLICATION_READINESS_THRESHOLD = 7
+PUBLICATION_HIGH_RISK_ACTIONS = {"rewrite", "bridge", "compress", "humanize", "vary_scene", "merge", "cut"}
+
+
+def _quality_profile_value(run: GenerationRun) -> str:
+    return str(getattr(run, "quality_profile", "balanced") or "balanced").strip().lower()
+
+
+def _is_publication_run(run: GenerationRun) -> bool:
+    return _quality_profile_value(run) == "publication"
 
 
 def _dedupe(items: list[str]) -> list[str]:
@@ -666,10 +678,24 @@ def _apply_quality_profile_to_critique(run: GenerationRun, critique: ChapterCrit
             }
         )
 
-    if profile != "strict":
+    if profile not in {"strict", "publication"}:
         return critique
 
     strict_warnings, scopes = _strict_quality_warnings(critique)
+    if profile == "publication":
+        publication_warnings = [
+            "Publication profile requires character texture beyond role or discipline.",
+            "Publication profile requires repeated atmosphere and crisis mechanics to be reduced before export.",
+        ]
+        if critique.repetition_risk_score >= 5:
+            publication_warnings.append(
+                f"Publication profile wants repetition reduced: repetition risk {critique.repetition_risk_score}/10."
+            )
+            scopes.append("voice_and_texture")
+        if critique.emotional_depth_score <= 6 or critique.dialogue_tension_score <= 6:
+            publication_warnings.append("Publication profile wants more ordinary human friction and subtext.")
+            scopes.append("voice_and_texture")
+        strict_warnings = _dedupe([*strict_warnings, *publication_warnings])
     if not strict_warnings:
         return critique
 
@@ -1640,6 +1666,9 @@ def _run_manuscript_qa(
     qa_report = qa_report.model_copy(
         update={
             "lint_findings": _dedupe([*qa_report.lint_findings, *lint_findings]),
+            "repetition_risks": _dedupe(
+                [*qa_report.repetition_risks, *deterministic_notes.get("repetition_risks", [])]
+            ),
             "chapter_ending_quality_notes": _dedupe(
                 [*qa_report.chapter_ending_quality_notes, *deterministic_notes["chapter_ending_quality_notes"]]
             ),
@@ -1751,6 +1780,425 @@ def _fallback_developmental_rewrite_plan(
     )
 
 
+def _publication_qa_risk_count(qa_report: ManuscriptQaReport) -> int:
+    risk_lists = [
+        qa_report.warnings,
+        qa_report.continuity_risks,
+        qa_report.repetition_risks,
+        qa_report.chapter_ending_quality_notes,
+        qa_report.easy_win_warnings,
+        qa_report.side_character_agency_notes,
+        qa_report.atmospheric_repetition_findings,
+        qa_report.emotional_pacing_notes,
+        qa_report.technical_escalation_fatigue_findings,
+        qa_report.crisis_loop_findings,
+        qa_report.scene_mode_distribution_notes,
+        qa_report.story_turn_quality_notes,
+        qa_report.continuity_bible_findings,
+    ]
+    return sum(len(items) for items in risk_lists)
+
+
+def _publication_action_for_chapter(chapter: Any, qa_report: ManuscriptQaReport) -> DevelopmentalChapterAction:
+    qa_notes = chapter.qa_notes or {}
+    repetition_risk = int(qa_notes.get("repetition_risk_score") or 0)
+    technical_fatigue = int(qa_notes.get("technical_escalation_fatigue_score") or 0)
+    side_character_score = int(qa_notes.get("side_character_independence_score") or 10)
+    emotional_score = int(qa_notes.get("emotional_depth_score") or 10)
+    dialogue_score = int(qa_notes.get("dialogue_tension_score") or 10)
+    cuttable_risk = int(qa_notes.get("cuttable_chapter_risk_score") or 0)
+    story_turn_score = int(qa_notes.get("irreversibility_score") or 10)
+    warning_text = " ".join(
+        [
+            *qa_notes.get("warnings", []),
+            *qa_notes.get("soft_warnings", []),
+            *qa_notes.get("blocking_issues", []),
+        ]
+    ).lower()
+
+    action = "keep"
+    reason = "Chapter has no high publication-specific deterministic risk."
+    if repetition_risk >= 6 or "repetition" in warning_text or chapter.word_count > (chapter.run.max_words_per_chapter if chapter.run else 999999):
+        action = "compress"
+        reason = "Reduce repeated motifs, explanation, and generated-feeling density."
+    if technical_fatigue >= 6 or "crisis-loop" in warning_text or "technical" in warning_text:
+        action = "vary_scene" if action == "keep" else action
+        reason = "Vary repeated crisis mechanics and translate system pressure into human consequence."
+    if side_character_score <= 5 or emotional_score <= 6 or dialogue_score <= 6:
+        action = "humanize" if action == "keep" else action
+        reason = "Sharpen ordinary human friction, private motive, subtext, and side-character agency."
+    if cuttable_risk >= 6 or story_turn_score <= 5:
+        action = "rewrite"
+        reason = "Make the chapter carry a concrete non-cuttable story turn."
+
+    global_risks = " ".join(
+        [
+            *qa_report.repetition_risks,
+            *qa_report.atmospheric_repetition_findings,
+            *qa_report.crisis_loop_findings,
+            *qa_report.side_character_agency_notes,
+        ]
+    ).lower()
+    if action == "keep" and str(chapter.chapter_number) in global_risks:
+        action = "compress"
+        reason = "Full-manuscript QA flagged this chapter in a publication-readiness risk."
+
+    story_turn = (chapter.continuity_update or {}).get("story_turn", {}) if isinstance(chapter.continuity_update, dict) else {}
+    return DevelopmentalChapterAction(
+        chapter_numbers=[chapter.chapter_number],
+        action=action,
+        reason=reason,
+        required_story_change=story_turn.get("why_this_chapter_cannot_be_cut") or chapter.outline_summary,
+        permanent_consequence=story_turn.get("permanent_consequence") or "Preserve the chapter's concrete before/after state change.",
+    )
+
+
+def _supplement_publication_developmental_plan(
+    run: GenerationRun,
+    chapters: list,
+    qa_report: ManuscriptQaReport,
+    plan: DevelopmentalRewritePlan,
+) -> DevelopmentalRewritePlan:
+    if not _is_publication_run(run):
+        return plan
+
+    existing_by_chapter = _developmental_actions_by_chapter(plan)
+    supplemented = list(plan.chapter_actions)
+    missing_actions: list[DevelopmentalChapterAction] = []
+    meaningful_risks = _publication_qa_risk_count(qa_report) > 0
+    for chapter in chapters:
+        existing = existing_by_chapter.get(chapter.chapter_number)
+        if existing and existing.action in PUBLICATION_HIGH_RISK_ACTIONS:
+            continue
+        fallback = _publication_action_for_chapter(chapter, qa_report)
+        if existing is None and (meaningful_risks or fallback.action != "keep"):
+            missing_actions.append(fallback)
+        elif existing and existing.action in {"", "keep", "none", "no_change"} and fallback.action != "keep":
+            missing_actions.append(fallback)
+
+    if not missing_actions:
+        return plan
+
+    return plan.model_copy(
+        update={
+            "overall_diagnosis": (
+                plan.overall_diagnosis
+                + " Publication profile supplemented the plan with deterministic chapter actions where QA risks needed stronger intervention."
+            ).strip(),
+            "chapter_actions": [*supplemented, *missing_actions],
+            "pre_rewrite_risks": _dedupe(
+                [*plan.pre_rewrite_risks, "Publication profile found QA risks that required deterministic fallback chapter actions."]
+            ),
+            "post_rewrite_risk_targets": _dedupe(
+                [
+                    *plan.post_rewrite_risk_targets,
+                    "Publication QA should show lower motif repetition, less crisis-loop sameness, and stronger character-specific human friction.",
+                ]
+            ),
+        }
+    )
+
+
+def _completed_event_chapters(run: GenerationRun, event_type: str) -> set[int]:
+    completed: set[int] = set()
+    for event in run.events:
+        if event.event_type != event_type:
+            continue
+        chapter_number = event.payload.get("chapter_number")
+        try:
+            completed.add(int(chapter_number))
+        except (TypeError, ValueError):
+            continue
+    return completed
+
+
+def _publication_humanization_targets(chapters: list, qa_report: ManuscriptQaReport) -> list:
+    global_humanization_risk = bool(qa_report.side_character_agency_notes or qa_report.emotional_pacing_notes)
+    targets = []
+    for chapter in chapters:
+        qa_notes = chapter.qa_notes or {}
+        if (
+            int(qa_notes.get("side_character_independence_score") or 10) <= 6
+            or int(qa_notes.get("emotional_depth_score") or 10) <= 6
+            or int(qa_notes.get("dialogue_tension_score") or 10) <= 6
+            or int(qa_notes.get("voice_distinctness_score") or 10) <= 6
+            or (global_humanization_risk and chapter.chapter_number <= 3)
+        ):
+            targets.append(chapter)
+    return targets
+
+
+def _publication_compression_targets(run: GenerationRun, chapters: list, qa_report: ManuscriptQaReport) -> list:
+    global_compression_risk = bool(
+        qa_report.repetition_risks
+        or qa_report.atmospheric_repetition_findings
+        or qa_report.technical_escalation_fatigue_findings
+        or qa_report.crisis_loop_findings
+    )
+    targets = []
+    for chapter in chapters:
+        qa_notes = chapter.qa_notes or {}
+        if (
+            chapter.word_count > run.max_words_per_chapter
+            or int(qa_notes.get("repetition_risk_score") or 0) >= 5
+            or int(qa_notes.get("technical_escalation_fatigue_score") or 0) >= 6
+            or (global_compression_risk and chapter.chapter_number <= 4)
+        ):
+            targets.append(chapter)
+    return targets
+
+
+def _run_publication_humanization_pass(
+    session: Session,
+    run: GenerationRun,
+    chapters: list,
+    qa_report: ManuscriptQaReport,
+    client: ProviderManager | OllamaClient,
+) -> None:
+    if not _is_publication_run(run):
+        return
+    story_bible = _story_bible_from_run(run)
+    continuity_ledger = _continuity_ledger_from_run(run)
+    provider_name, model_name = _resolve_stage_route(client, run, "chapter_revision")
+    completed = _completed_event_chapters(run, "publication_chapter_humanization_completed")
+    targets = [chapter for chapter in _publication_humanization_targets(chapters, qa_report) if chapter.chapter_number not in completed]
+    if not targets:
+        record_event(session, run, "publication_humanization_skipped", {"message": "No publication humanization targets were needed."})
+        session.commit()
+        return
+
+    run.current_step = "chapter_humanization"
+    run.current_chapter = None
+    record_event(
+        session,
+        run,
+        "publication_humanization_started",
+        {"message": "Running publication character humanization pass.", "chapters": len(targets)},
+    )
+    session.commit()
+
+    for chapter in targets:
+        _ensure_not_canceled(session, run)
+        run.current_step = "chapter_humanization"
+        run.current_chapter = chapter.chapter_number
+        before_word_count = chapter.word_count
+        try:
+            outline_entry = _outline_entry(run, chapter.chapter_number)
+            revised_content = sanitize_chapter_content(
+                _supervised_provider_chat(
+                    session,
+                    run,
+                    client,
+                    provider_name,
+                    model_name,
+                    build_publication_humanization_messages(
+                        run.project,
+                        chapter,
+                        outline_entry,
+                        story_bible,
+                        continuity_ledger,
+                        qa_report,
+                    ),
+                    stage="chapter_humanization",
+                    chapter_number=chapter.chapter_number,
+                    metadata={"label": f"chapter {chapter.chapter_number} publication humanization"},
+                )
+            )
+            if not revised_content.strip():
+                raise RuntimeError(f"Chapter {chapter.chapter_number} publication humanization was empty.")
+            chapter.content = revised_content
+            chapter.word_count = len((chapter.content or "").split())
+            record_event(
+                session,
+                run,
+                "publication_chapter_humanization_completed",
+                {
+                    "message": f"Publication humanization saved for chapter {chapter.chapter_number}.",
+                    "chapter_number": chapter.chapter_number,
+                    "before_word_count": before_word_count,
+                    "after_word_count": chapter.word_count,
+                },
+            )
+            session.commit()
+        except Exception as exc:
+            chapter.word_count = len((chapter.content or "").split())
+            record_event(
+                session,
+                run,
+                "publication_chapter_humanization_fallback",
+                {
+                    "message": f"Publication humanization failed for chapter {chapter.chapter_number}; kept existing prose.",
+                    "chapter_number": chapter.chapter_number,
+                    "error": str(exc),
+                },
+            )
+            session.commit()
+
+    run.current_chapter = None
+    record_event(session, run, "publication_humanization_completed", {"message": "Publication humanization pass completed.", "chapters": len(targets)})
+    session.commit()
+
+
+def _run_publication_compression_pass(
+    session: Session,
+    run: GenerationRun,
+    chapters: list,
+    qa_report: ManuscriptQaReport,
+    client: ProviderManager | OllamaClient,
+) -> None:
+    if not _is_publication_run(run):
+        return
+    story_bible = _story_bible_from_run(run)
+    continuity_ledger = _continuity_ledger_from_run(run)
+    provider_name, model_name = _resolve_stage_route(client, run, "chapter_revision")
+    completed = _completed_event_chapters(run, "publication_chapter_compression_completed")
+    targets = [chapter for chapter in _publication_compression_targets(run, chapters, qa_report) if chapter.chapter_number not in completed]
+    if not targets:
+        record_event(session, run, "publication_compression_skipped", {"message": "No publication compression targets were needed."})
+        session.commit()
+        return
+
+    run.current_step = "chapter_compression"
+    run.current_chapter = None
+    record_event(
+        session,
+        run,
+        "publication_compression_started",
+        {"message": "Running publication prose compression pass.", "chapters": len(targets)},
+    )
+    session.commit()
+
+    for chapter in targets:
+        _ensure_not_canceled(session, run)
+        run.current_step = "chapter_compression"
+        run.current_chapter = chapter.chapter_number
+        before_word_count = chapter.word_count
+        try:
+            outline_entry = _outline_entry(run, chapter.chapter_number)
+            revised_content = sanitize_chapter_content(
+                _supervised_provider_chat(
+                    session,
+                    run,
+                    client,
+                    provider_name,
+                    model_name,
+                    build_publication_compression_messages(
+                        run.project,
+                        chapter,
+                        outline_entry,
+                        story_bible,
+                        continuity_ledger,
+                        qa_report,
+                    ),
+                    stage="chapter_compression",
+                    chapter_number=chapter.chapter_number,
+                    metadata={"label": f"chapter {chapter.chapter_number} publication compression"},
+                )
+            )
+            if not revised_content.strip():
+                raise RuntimeError(f"Chapter {chapter.chapter_number} publication compression was empty.")
+            chapter.content = revised_content
+            chapter.word_count = len((chapter.content or "").split())
+            record_event(
+                session,
+                run,
+                "publication_chapter_compression_completed",
+                {
+                    "message": f"Publication compression saved for chapter {chapter.chapter_number}.",
+                    "chapter_number": chapter.chapter_number,
+                    "before_word_count": before_word_count,
+                    "after_word_count": chapter.word_count,
+                    "word_delta": chapter.word_count - before_word_count,
+                },
+            )
+            session.commit()
+        except Exception as exc:
+            chapter.word_count = len((chapter.content or "").split())
+            record_event(
+                session,
+                run,
+                "publication_chapter_compression_fallback",
+                {
+                    "message": f"Publication compression failed for chapter {chapter.chapter_number}; kept existing prose.",
+                    "chapter_number": chapter.chapter_number,
+                    "error": str(exc),
+                },
+            )
+            session.commit()
+
+    run.current_chapter = None
+    record_event(session, run, "publication_compression_completed", {"message": "Publication compression pass completed.", "chapters": len(targets)})
+    session.commit()
+
+
+def _bounded_publication_score(base: int, penalty: int) -> int:
+    return max(1, min(10, base - penalty))
+
+
+def _apply_publication_readiness_gate(
+    session: Session,
+    run: GenerationRun,
+    qa_report: ManuscriptQaReport,
+) -> ManuscriptQaReport:
+    if not _is_publication_run(run):
+        return qa_report
+
+    run.current_step = "publication_readiness"
+    run.current_chapter = None
+    repetition_penalty = min(5, (len(qa_report.repetition_risks) + len(qa_report.atmospheric_repetition_findings)) // 2)
+    technical_penalty = min(4, (len(qa_report.technical_escalation_fatigue_findings) + len(qa_report.crisis_loop_findings)) // 2)
+    continuity_penalty = min(4, (len(qa_report.continuity_risks) + len(qa_report.continuity_bible_findings)) // 3)
+    character_penalty = min(5, (len(qa_report.side_character_agency_notes) + len(qa_report.emotional_pacing_notes)) // 2)
+    prose_penalty = min(5, len(qa_report.lint_findings) // 3 + repetition_penalty)
+    scores = {
+        "concept_world": _bounded_publication_score(8, max(0, len(qa_report.genre_contract_notes) // 5)),
+        "atmosphere": _bounded_publication_score(8, repetition_penalty),
+        "thematic_ambition": _bounded_publication_score(8, max(0, len(qa_report.ideology_consistency_findings) // 4)),
+        "plot_coherence": _bounded_publication_score(8, continuity_penalty + min(2, len(qa_report.story_turn_quality_notes) // 4)),
+        "character_depth": _bounded_publication_score(8, character_penalty),
+        "prose_control": _bounded_publication_score(8, prose_penalty + min(2, technical_penalty)),
+        "repetition_control": _bounded_publication_score(8, repetition_penalty + technical_penalty),
+    }
+    publication_readiness = min(
+        scores["plot_coherence"],
+        scores["character_depth"],
+        scores["prose_control"],
+        scores["repetition_control"],
+    )
+    scores["publication_readiness"] = publication_readiness
+    label = "publication-ready" if publication_readiness >= PUBLICATION_READINESS_THRESHOLD else "needs editorial revision"
+    summary = (
+        "Final QA gate passed the publication-readiness threshold."
+        if label == "publication-ready"
+        else "Final QA completed, but this should be treated as a reviewable manuscript that still needs editorial revision before publication."
+    )
+    warnings = qa_report.warnings
+    if label != "publication-ready":
+        warnings = _dedupe([*warnings, "Publication readiness gate says this manuscript still needs editorial revision."])
+
+    gated = qa_report.model_copy(
+        update={
+            "warnings": warnings,
+            "publication_readiness_scores": scores,
+            "publication_readiness_label": label,
+            "publication_readiness_summary": summary,
+        }
+    )
+    record_event(
+        session,
+        run,
+        "publication_readiness_completed",
+        {
+            "message": summary,
+            "label": label,
+            "publication_readiness_score": publication_readiness,
+            "threshold": PUBLICATION_READINESS_THRESHOLD,
+        },
+    )
+    session.commit()
+    return gated
+
+
 def _run_developmental_rewrite(
     session: Session,
     run: GenerationRun,
@@ -1790,6 +2238,20 @@ def _run_developmental_rewrite(
         )
         session.commit()
         plan = _fallback_developmental_rewrite_plan(chapters, qa_report)
+
+    supplemented_plan = _supplement_publication_developmental_plan(run, chapters, qa_report, plan)
+    if supplemented_plan != plan:
+        plan = supplemented_plan
+        record_event(
+            session,
+            run,
+            "publication_developmental_plan_supplemented",
+            {
+                "message": "Publication profile supplemented the developmental plan with deterministic QA-driven actions.",
+                "chapter_action_count": len(plan.chapter_actions),
+            },
+        )
+        session.commit()
 
     rewrite_markdown = render_developmental_rewrite_report_markdown(plan, qa_report)
     revised_outline_markdown = render_revised_outline_markdown(run.project.title, plan, chapters)
@@ -2155,7 +2617,7 @@ def process_run(session: Session, run: GenerationRun, settings: Settings, client
     rewrite_markdown = None
     revised_outline_markdown = None
     developmental_qa_markdown = None
-    if run.developmental_rewrite_enabled:
+    if run.developmental_rewrite_enabled or _is_publication_run(run):
         developmental_plan, rewrite_markdown, revised_outline_markdown, developmental_qa_markdown = _run_developmental_rewrite(
             session,
             run,
@@ -2164,10 +2626,14 @@ def process_run(session: Session, run: GenerationRun, settings: Settings, client
             client,
         )
         _run_developmental_revision_waves(session, run, completed_chapters, qa_report, developmental_plan, client)
+        _run_publication_humanization_pass(session, run, completed_chapters, qa_report, client)
+        _run_publication_compression_pass(session, run, completed_chapters, qa_report, client)
 
     _run_final_editing_pass(session, run, completed_chapters, qa_report, developmental_plan, client)
     completed_chapters = _require_requested_chapters(session, run)
     qa_report, qa_markdown = _run_manuscript_qa(session, run, completed_chapters, client)
+    qa_report = _apply_publication_readiness_gate(session, run, qa_report)
+    qa_markdown = render_qa_report_markdown(qa_report)
 
     run.current_step = "export"
     record_event(session, run, "artifact_export_started", {"message": "Rendering manuscript artifacts."})

--- a/src/novel_generator/services/prompts.py
+++ b/src/novel_generator/services/prompts.py
@@ -57,6 +57,55 @@ def _genre_profile_block(profile: GenreProfile) -> str:
     return json.dumps(_genre_profile_payload(profile), indent=2)
 
 
+def _quality_profile_value(run: GenerationRun) -> str:
+    return str(getattr(run, "quality_profile", "balanced") or "balanced").strip().lower()
+
+
+def _is_publication_profile(run: GenerationRun) -> bool:
+    return _quality_profile_value(run) == "publication"
+
+
+def _publication_draft_range(run: GenerationRun) -> tuple[int, int]:
+    return (max(1, math.ceil(run.min_words_per_chapter * 1.15)), max(1, math.ceil(run.max_words_per_chapter * 1.15)))
+
+
+def _publication_story_bible_requirements(run: GenerationRun) -> str:
+    if not _is_publication_profile(run):
+        return ""
+    return (
+        "- publication profile: define private wants, fears, resentments, tenderness, irrational choices, ordinary relationship friction, and voice contrast for every major character\n"
+        "- publication profile: do not let characters function only as disciplines, ideologies, jobs, or exposition engines; each major character needs a non-thematic personal want\n"
+        "- publication profile: give the imagery palette a motif budget by naming overused motifs to ration and alternative textures to rotate in later chapters\n"
+    )
+
+
+def _publication_outline_requirements(run: GenerationRun) -> str:
+    if not _is_publication_profile(run):
+        return ""
+    long_book_note = (
+        "- publication profile for long books: across 32+ or 64+ chapters, force quiet relationship scenes, political/social scenes, civilian aftermath, and moments of beauty or absurdity between crisis chapters\n"
+        if run.requested_chapters >= 32
+        else ""
+    )
+    return (
+        "- publication profile: include scene variety as a structural requirement, not garnish; avoid repeating enter-location -> debate-system -> deeper-flaw -> authority-intervenes -> crisis -> breakthrough loops\n"
+        "- publication profile: no more than 2 of any 6 adjacent chapters may use the same infrastructure or system-crisis pattern\n"
+        "- publication profile: each act must include at least one chapter driven primarily by relationship friction, one by civic/political consequence, and one by aftermath or daily life texture when chapter count allows\n"
+        f"{long_book_note}"
+    )
+
+
+def _publication_draft_requirements(run: GenerationRun) -> str:
+    if not _is_publication_profile(run):
+        return ""
+    draft_min, draft_max = _publication_draft_range(run)
+    return (
+        f"- publication profile draft-long-then-cut target: draft about 115% of the final range now ({draft_min}-{draft_max} words) so a later compression pass can cut repeated explanation and filler back toward {run.min_words_per_chapter}-{run.max_words_per_chapter}\n"
+        "- publication profile motif budget: do not lean repeatedly on the same atmosphere words; ration damp, brine, pressure, resonance, structural, truth, memory, guilt, wet stone, copper, and similar signature motifs\n"
+        "- publication profile character rule: every major scene must include one ordinary human beat such as fear, jealousy, tenderness, shame, humor, fatigue, private desire, resentment, or contradiction that is not merely thematic exposition\n"
+    )
+
+
 def _chapter_continuity_payload(chapter: ChapterDraft) -> dict[str, Any]:
     payload = chapter.continuity_update or {}
     if isinstance(payload, dict):
@@ -254,7 +303,8 @@ def build_story_bible_messages(project: Project, run: GenerationRun) -> list[dic
                 "- if a style reference is provided, infer durable craft guidance from it without copying its exact sentences, imagery, names, or distinctive phrasing\n"
                 "- character_voice_map must give each major character a distinct pressure behavior, dialogue texture, and default verbal rhythm\n"
                 "- style_profile.avoid must include the user's style avoid items plus any generic prose habits that would make the draft sound flat\n"
-                "- keep the tone and world rules specific enough to govern later chapters"
+                + _publication_story_bible_requirements(run)
+                + "- keep the tone and world rules specific enough to govern later chapters"
             ),
         },
     ]
@@ -344,7 +394,8 @@ def build_outline_messages(project: Project, run: GenerationRun, story_bible: St
                 "- include profile-specific outline focus: "
                 + "; ".join(profile.outline_focus)
                 + "\n"
-                "- preserve one clean climax and one primary ending in the final chapter"
+                + _publication_outline_requirements(run)
+                + "- preserve one clean climax and one primary ending in the final chapter"
             ),
         },
     ]
@@ -432,7 +483,8 @@ def build_outline_chunk_messages(
                 "- cost_if_success must describe the price of progress, not just the risk of failure\n"
                 "- concrete_ending_hook must end on a specific actor, object, interruption, arrival, discovery, or reversal\n"
                 "- civilian_life_detail, emotional_reveal, ideology_pressure, genre_specific_beats, and genre_state_change must be filled for every chapter\n"
-                "- preserve one clean climax and one primary ending in the final chapter only"
+                + _publication_outline_requirements(run)
+                + "- preserve one clean climax and one primary ending in the final chapter only"
             ),
         },
     ]
@@ -538,7 +590,8 @@ def build_chapter_plan_messages(
                 "- include profile-specific planning focus: "
                 + "; ".join(profile.drafting_focus)
                 + "\n"
-                "- the ending_hook_delivery must describe the specific final beat that lands the outline's concrete_ending_hook"
+                + _publication_draft_requirements(run)
+                + "- the ending_hook_delivery must describe the specific final beat that lands the outline's concrete_ending_hook"
             ),
         },
     ]
@@ -610,7 +663,8 @@ def build_chapter_draft_messages(
                 "- honor profile-specific drafting focus: "
                 + "; ".join(profile.drafting_focus)
                 + "\n"
-                "- limit new system acronyms in breather or aftermath chapters unless absolutely necessary\n"
+                + _publication_draft_requirements(run)
+                + "- limit new system acronyms in breather or aftermath chapters unless absolutely necessary\n"
                 "- do not include meta-drafting or outline language in the prose, including phrases like 'The chapter ends on', 'This lays the groundwork for', 'pushing the story forward', or 'in the next chapter'\n"
                 "- do not introduce abstract chapter endings about destiny, choices, or the future hanging in the balance\n"
                 "- the final paragraph must include a concrete external action, visible consequence, irreversible decision, reveal, reversal, or state change\n"
@@ -1191,6 +1245,101 @@ def build_developmental_revision_messages(
                 "- keep continuity stable with the chapter continuity state and current ledger\n"
                 "- do not include an editorial memo, diff, heading, outline summary, or future-planning language\n\n"
                 "Return revised chapter prose only."
+            ),
+        },
+    ]
+
+
+def build_publication_humanization_messages(
+    project: Project,
+    chapter: ChapterDraft,
+    outline_entry: StructuredOutlineEntry | dict[str, Any],
+    story_bible: StoryBible | dict[str, Any],
+    continuity_ledger: ContinuityLedger | dict[str, Any],
+    qa_report: ManuscriptQaReport,
+) -> list[dict[str, str]]:
+    entry = outline_entry if isinstance(outline_entry, dict) else outline_entry.model_dump()
+    bible = story_bible if isinstance(story_bible, dict) else story_bible.model_dump()
+    ledger = continuity_ledger if isinstance(continuity_ledger, dict) else continuity_ledger.model_dump()
+    profile = _story_bible_genre_profile(bible)
+    style_profile = bible.get("style_profile") or {}
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a fiction editor specializing in human character texture. "
+                "Return revised chapter prose only, with no heading, notes, JSON, or markdown fences."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Humanize chapter {chapter.chapter_number} of '{project.title}' for publication-quality fiction.\n\n"
+                f"Story bible:\n{json.dumps(bible, indent=2)}\n\n"
+                f"Selected genre profile:\n{_genre_profile_block(profile)}\n\n"
+                f"Prose style profile:\n{json.dumps(style_profile, indent=2)}\n\n"
+                f"Chapter outline:\n{json.dumps(entry, indent=2)}\n\n"
+                f"Continuity ledger:\n{json.dumps(ledger, indent=2)}\n\n"
+                f"Manuscript QA context:\n{json.dumps(_qa_editing_context(qa_report), indent=2)}\n\n"
+                f"Current chapter prose:\n{chapter.content or ''}\n\n"
+                "Humanization rules:\n"
+                "- preserve plot events, continuity outcome, chapter order, POV, and named canon\n"
+                "- keep the same basic scene but make characters sound like people, not embodiments of disciplines, job titles, or ideologies\n"
+                "- add or sharpen one ordinary human beat where the scene supports it: fear, jealousy, tenderness, humor, fatigue, shame, resentment, private desire, or contradiction\n"
+                "- replace neutral explanation with subtext, disagreement, evasion, memory, embarrassment, care, or irritation when it can carry the same information\n"
+                "- give any major side character on page one independent want or friction that is not only warning, calculating, validating, or explaining\n"
+                "- do not add a new subplot, new canon entity, new scene break, author note, or chapter heading\n"
+                "- avoid melodrama; the human beat should feel specific, small enough to believe, and consequential enough to change how the reader understands the character\n\n"
+                "Return revised chapter prose only."
+            ),
+        },
+    ]
+
+
+def build_publication_compression_messages(
+    project: Project,
+    chapter: ChapterDraft,
+    outline_entry: StructuredOutlineEntry | dict[str, Any],
+    story_bible: StoryBible | dict[str, Any],
+    continuity_ledger: ContinuityLedger | dict[str, Any],
+    qa_report: ManuscriptQaReport,
+) -> list[dict[str, str]]:
+    entry = outline_entry if isinstance(outline_entry, dict) else outline_entry.model_dump()
+    bible = story_bible if isinstance(story_bible, dict) else story_bible.model_dump()
+    ledger = continuity_ledger if isinstance(continuity_ledger, dict) else continuity_ledger.model_dump()
+    profile = _story_bible_genre_profile(bible)
+    style_profile = bible.get("style_profile") or {}
+    target_min = chapter.run.min_words_per_chapter if chapter.run else "configured minimum"
+    target_max = chapter.run.max_words_per_chapter if chapter.run else "configured maximum"
+    return [
+        {
+            "role": "system",
+            "content": (
+                "You are a publication line editor doing a ruthless but continuity-safe prose compression pass. "
+                "Return revised chapter prose only, with no heading, notes, JSON, or markdown fences."
+            ),
+        },
+        {
+            "role": "user",
+            "content": (
+                f"Compress chapter {chapter.chapter_number} of '{project.title}' after the long-draft pass.\n\n"
+                f"Story bible:\n{json.dumps(bible, indent=2)}\n\n"
+                f"Selected genre profile:\n{_genre_profile_block(profile)}\n\n"
+                f"Prose style profile:\n{json.dumps(style_profile, indent=2)}\n\n"
+                f"Chapter outline:\n{json.dumps(entry, indent=2)}\n\n"
+                f"Continuity ledger:\n{json.dumps(ledger, indent=2)}\n\n"
+                f"Manuscript QA context:\n{json.dumps(_qa_editing_context(qa_report), indent=2)}\n\n"
+                f"Current word count: {chapter.word_count}. Final target range: {target_min}-{target_max}.\n\n"
+                f"Current chapter prose:\n{chapter.content or ''}\n\n"
+                "Compression rules:\n"
+                "- preserve plot events, continuity outcome, chapter order, POV, named canon, and the final concrete story state\n"
+                "- trim 15-25% when the chapter is bloated, but do not cut below the final target range if the chapter is already short\n"
+                "- cut repeated explanation, thesis statements, duplicated emotional labeling, and repeated atmospheric setup before cutting action or dialogue\n"
+                "- reduce repeated motifs and generated-feeling clusters such as damp, brine, pressure, resonance, structural, truth, memory, guilt, wet stone, copper, and similar signature terms\n"
+                "- vary paragraph shape and keep only the sensory details that reveal character, conflict, or world state\n"
+                "- keep the ending concrete and visible; do not replace it with a summary of theme or future stakes\n"
+                "- do not add a new scene, new twist, new system rule, new character, chapter heading, author note, or outline summary\n\n"
+                "Return compressed chapter prose only."
             ),
         },
     ]

--- a/src/novel_generator/static/ui.js
+++ b/src/novel_generator/static/ui.js
@@ -195,7 +195,7 @@ function setupQualityProfileControls(root) {
       if (note && selected) {
         note.textContent = selected.dataset.profileNote || "";
       }
-      if (rewriteToggle && selected?.value === "strict") {
+      if (rewriteToggle && (selected?.value === "strict" || selected?.value === "publication")) {
         rewriteToggle.checked = true;
       }
     };

--- a/src/novel_generator/templates/project_detail.html
+++ b/src/novel_generator/templates/project_detail.html
@@ -584,7 +584,7 @@
 
       <label class="toggle-card run-mode-card">
         <span class="toggle-input">
-          <input data-developmental-rewrite-toggle type="checkbox" name="developmental_rewrite_enabled" value="1" {% if run_values.developmental_rewrite_enabled or run_values.quality_profile == "strict" %}checked{% endif %}>
+          <input data-developmental-rewrite-toggle type="checkbox" name="developmental_rewrite_enabled" value="1" {% if run_values.developmental_rewrite_enabled or run_values.quality_profile in ["strict", "publication"] %}checked{% endif %}>
           <strong>Include developmental rewrite planning</strong>
         </span>
         <span class="field-note">Standard for polished book runs. After manuscript QA, produce a structural rewrite report, revised outline, and QA comparison before the final chapter edit pass.</span>

--- a/src/novel_generator/templates/run_detail.html
+++ b/src/novel_generator/templates/run_detail.html
@@ -1280,8 +1280,8 @@
   <article class="panel" id="publication-export">
     <div class="section-header">
       <div class="section-header-copy">
-        <h2>Export For Publication</h2>
-        <p>Create an ebook or print-helper manuscript with front matter and profile-specific formatting.</p>
+        <h2>Export Layout Helper</h2>
+        <p>Create an ebook or print-helper manuscript with real front matter and profile-specific formatting.</p>
       </div>
       <p>Optional</p>
     </div>
@@ -1298,11 +1298,41 @@
           </label>
           <label class="checkbox-row">
             <input type="checkbox" name="include_ai_disclosure" value="1">
-            Include AI-assisted disclosure placeholder
+            Include AI-assisted disclosure
           </label>
         </div>
-        <p class="field-note">Print-ready exports are formatting helpers for review and cleanup, not a platform acceptance guarantee.</p>
-        <button type="submit">Create publication export</button>
+        <div class="field-grid two-column">
+          <label>
+            Author name
+            <input name="author_name" required>
+          </label>
+          <label>
+            Copyright year
+            <input name="copyright_year" required>
+          </label>
+          <label>
+            Publisher or imprint
+            <input name="publisher" required>
+          </label>
+          <label>
+            ISBN
+            <input name="isbn">
+          </label>
+        </div>
+        <label>
+          Dedication
+          <textarea name="dedication" rows="2" required></textarea>
+        </label>
+        <label>
+          Author note
+          <textarea name="author_note" rows="3" required></textarea>
+        </label>
+        <label>
+          AI-assisted disclosure text
+          <textarea name="ai_disclosure" rows="2"></textarea>
+        </label>
+        <p class="field-note">These are layout helpers for review and cleanup. Publication-profile runs include a readiness verdict in QA, but no export guarantees platform acceptance.</p>
+        <button type="submit">Create layout export</button>
       </form>
     {% else %}
       <p class="empty-state">Publication exports become available after the run completes.</p>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -186,6 +186,23 @@ def test_strict_quality_profile_enables_developmental_rewrite_by_default(client,
     assert response.json()["developmental_rewrite_enabled"] is True
 
 
+def test_publication_quality_profile_forces_outline_review_and_developmental_rewrite(client, monkeypatch) -> None:
+    monkeypatch.setattr(OllamaClient, "list_models", lambda self: ["test-model"])
+
+    _, run_id = create_project_and_run(
+        client,
+        pause_after_outline=False,
+        developmental_rewrite_enabled=False,
+        quality_profile="publication",
+    )
+
+    response = client.get(f"/api/runs/{run_id}")
+    assert response.status_code == 200
+    assert response.json()["quality_profile"] == "publication"
+    assert response.json()["pause_after_outline"] is True
+    assert response.json()["developmental_rewrite_enabled"] is True
+
+
 def test_invalid_quality_profile_is_rejected_when_queueing_run(client, monkeypatch) -> None:
     monkeypatch.setattr(OllamaClient, "list_models", lambda self: ["test-model"])
 

--- a/tests/test_editorial.py
+++ b/tests/test_editorial.py
@@ -394,6 +394,45 @@ def test_lint_flags_adjacent_technical_emergency_repetition() -> None:
     assert any("same scene mode" in item.lower() for item in result.soft_warnings)
 
 
+def test_manuscript_diagnostics_flag_publication_repetition_patterns() -> None:
+    repeated_opening = (
+        "The damp pressure of memory settled over the wet stone while copper truth and structural resonance pressed down. "
+        "The damp pressure of memory settled over the wet stone while copper truth and structural resonance pressed down."
+    )
+    chapters = [
+        ChapterDraft(
+            chapter_number=1,
+            title="Signal",
+            outline_summary="Mode: systems_crisis",
+            content=(
+                repeated_opening
+                + '\n\n"The calculation of cartography and engineering theory proves the infrastructure system," Mara said. '
+                + " ".join(["memory pressure structural truth resonance"] * 20)
+            ),
+            status=ChapterStatus.COMPLETED,
+            summary="Mara finds the signal.",
+        ),
+        ChapterDraft(
+            chapter_number=2,
+            title="Echo",
+            outline_summary="Mode: systems_crisis",
+            content=repeated_opening + " " + " ".join(["control vulnerability agency consequence structure"] * 20),
+            status=ChapterStatus.COMPLETED,
+            summary="Mara follows the echo.",
+        ),
+    ]
+
+    lint_findings = lint_manuscript(chapters)
+    notes = manuscript_quality_notes(chapters, _story_bible())
+
+    assert any("Publication motif overuse" in finding for finding in lint_findings)
+    assert any("highly similar opening texture" in finding for finding in lint_findings)
+    assert any("abstract noun cluster" in finding for finding in lint_findings)
+    assert any("discipline labels" in finding for finding in lint_findings)
+    assert any("Publication motif overuse" in finding for finding in notes["atmospheric_repetition_findings"])
+    assert any("discipline labels" in finding for finding in notes["side_character_agency_notes"])
+
+
 def test_lint_flags_system_crisis_without_human_visible_consequence() -> None:
     chapter = ChapterDraft(
         chapter_number=2,

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -3,7 +3,26 @@ from __future__ import annotations
 from docx import Document
 
 from novel_generator.models import ChapterDraft, GenerationRun, Project
-from novel_generator.services.exports import export_publication_artifact, export_run_artifacts, publication_export_options
+from novel_generator.services.exports import (
+    PublicationFrontMatter,
+    export_publication_artifact,
+    export_run_artifacts,
+    publication_export_options,
+)
+
+
+def _front_matter(**overrides) -> PublicationFrontMatter:
+    values = {
+        "author_name": "Ada Writer",
+        "copyright_year": "2026",
+        "publisher": "Glass Orchard Press",
+        "dedication": "For the careful readers.",
+        "author_note": "A note about maps and memory.",
+        "isbn": "",
+        "ai_disclosure": "Drafting and editing used AI assistance under human direction.",
+    }
+    values.update(overrides)
+    return PublicationFrontMatter(**values)
 
 
 def test_export_run_artifacts_writes_manuscript_and_qa_report_without_duplicate_headings(tmp_path) -> None:
@@ -135,6 +154,7 @@ def test_publication_docx_profile_adds_front_matter_page_size_and_page_breaks(tm
         chapters,
         "print_6x9",
         include_ai_disclosure=True,
+        front_matter=_front_matter(isbn="978-1-23456-789-0"),
     )
 
     document = Document(tmp_path / artifact.relative_path)
@@ -145,10 +165,13 @@ def test_publication_docx_profile_adds_front_matter_page_size_and_page_breaks(tm
     assert artifact.filename == "publication-print-6x9.docx"
     assert round(document.sections[0].page_width.inches, 1) == 6.0
     assert round(document.sections[0].page_height.inches, 1) == 9.0
-    assert "Copyright (c) [Year] [Author Name]. All rights reserved." in text
+    assert "Copyright (c) 2026 Ada Writer. All rights reserved." in text
+    assert "Publisher: Glass Orchard Press" in text
+    assert "ISBN: 978-1-23456-789-0" in text
     assert "Dedication" in text
     assert "Author Note" in text
     assert "AI-Assisted Disclosure" in text
+    assert "[Author Name]" not in text
     assert "Chapter 1: Arrival" in text
     assert "Chapter 2: Descent" in text
     assert "**" not in text
@@ -182,7 +205,7 @@ def test_publication_markdown_profile_keeps_qa_separate_from_publication_artifac
     )
     chapter = ChapterDraft(chapter_number=1, title="Arrival", outline_summary="Wake the map.", content="A beginning.")
 
-    artifact = export_publication_artifact(tmp_path, project, run, [chapter], "ebook_markdown")
+    artifact = export_publication_artifact(tmp_path, project, run, [chapter], "ebook_markdown", front_matter=_front_matter())
     text = (tmp_path / artifact.relative_path).read_text(encoding="utf-8")
     profile_ids = {profile.id for profile in publication_export_options()}
 
@@ -191,4 +214,47 @@ def test_publication_markdown_profile_keeps_qa_separate_from_publication_artifac
     assert artifact.filename == "publication-ebook.md"
     assert "# QA Report" not in text
     assert "## Copyright" in text
+    assert "ISBN:" not in text
+    assert "[" not in text
     assert "## Chapter 1: Arrival" in text
+
+
+def test_publication_export_rejects_placeholder_front_matter(tmp_path) -> None:
+    project = Project(
+        title="The Glass Orchard",
+        premise="A disgraced archivist finds a living map under a failing city.",
+        desired_word_count=1000,
+        requested_chapters=1,
+        min_words_per_chapter=800,
+        max_words_per_chapter=1200,
+        preferred_provider_name="ollama",
+        preferred_model="test-model",
+        task_routing={},
+    )
+    run = GenerationRun(
+        id="run-1",
+        project_id="project-1",
+        provider_name="ollama",
+        model_name="test-model",
+        target_word_count=1000,
+        requested_chapters=1,
+        min_words_per_chapter=800,
+        max_words_per_chapter=1200,
+        task_routing={},
+        current_step="completed",
+    )
+    chapter = ChapterDraft(chapter_number=1, title="Arrival", outline_summary="Wake the map.", content="A beginning.")
+
+    try:
+        export_publication_artifact(
+            tmp_path,
+            project,
+            run,
+            [chapter],
+            "ebook_markdown",
+            front_matter=_front_matter(author_name="[Author Name]"),
+        )
+    except ValueError as exc:
+        assert "bracketed placeholders" in str(exc)
+    else:
+        raise AssertionError("placeholder front matter should be rejected")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -409,6 +409,23 @@ def _developmental_rewrite_json() -> str:
     )
 
 
+def _empty_developmental_rewrite_json() -> str:
+    return json.dumps(
+        {
+            "overall_diagnosis": "The model sees risks but did not assign chapter actions.",
+            "act_structure_notes": [],
+            "chapter_actions": [],
+            "merge_candidates": [],
+            "cut_candidates": [],
+            "continuity_repairs": [],
+            "theme_arc_repairs": [],
+            "prose_pattern_repairs": [],
+            "pre_rewrite_risks": ["The prose repeats its atmosphere."],
+            "post_rewrite_risk_targets": [],
+        }
+    )
+
+
 class FakeOllamaClient:
     def __init__(self, responses: list[str | Exception]):
         self._responses = iter(responses)
@@ -1355,6 +1372,90 @@ def test_draft_quality_profile_defers_non_blocking_revision(configured_environme
         qa_notes = refreshed.chapters[0].qa_notes
         assert qa_notes["revision_required"] is False
         assert "Draft profile deferred non-blocking revision work" in " ".join(qa_notes["soft_warnings"])
+
+
+def test_publication_profile_supplements_empty_developmental_plan_and_runs_quality_gates(configured_environment) -> None:
+    settings = get_settings()
+    session_factory = get_session_factory()
+    with session_factory() as session:
+        project = _create_project(session, requested_chapters=1)
+        run = create_run(
+            session,
+            project,
+            RunCreate(
+                project_id=project.id,
+                model_name="test-model",
+                pause_after_outline=False,
+                developmental_rewrite_enabled=False,
+                quality_profile="publication",
+            ),
+        )
+        session.commit()
+
+        run = get_run(session, run.id)
+        assert run is not None
+        process_run_safe(session, run, settings, FakeOllamaClient([_story_bible_json(), _outline_json(1)]))
+        paused = get_run(session, run.id)
+        assert paused.status == RunStatus.AWAITING_APPROVAL
+        assert paused.pause_after_outline is True
+        approve_outline_review(session, paused)
+        session.commit()
+
+        long_draft = " ".join(
+            [
+                "Iris explained the structural memory pressure while Tarin explained the system and the alarm kept repeating."
+            ]
+            * 180
+        )
+        revised = " ".join(["Iris made the chapter carry a visible irreversible cost."] * 120)
+        developmental_revision = " ".join(["Iris paid for progress while Tarin chose his own risk."] * 110)
+        humanized = " ".join(["Tarin joked once, then admitted he was jealous of Iris's certainty."] * 95)
+        compressed = " ".join(["Tarin admitted jealousy while Iris chose the cost."] * 80)
+        final_edit = " ".join(["Tarin admitted jealousy; Iris chose the cost and kept moving."] * 82)
+
+        process_run_safe(
+            session,
+            paused,
+            settings,
+            FakeOllamaClient(
+                [
+                    _plan_json(1),
+                    long_draft,
+                    _critique_json(revision_required=False),
+                    revised,
+                    _critique_json(revision_required=False),
+                    "Iris chooses the costly route while Tarin acts from his own fear.",
+                    _continuity_json(1),
+                    _qa_report_json(),
+                    _empty_developmental_rewrite_json(),
+                    developmental_revision,
+                    humanized,
+                    compressed,
+                    final_edit,
+                    _qa_report_json(),
+                ]
+            ),
+        )
+
+        refreshed = get_run(session, run.id)
+        assert refreshed.status == RunStatus.COMPLETED
+        assert refreshed.quality_profile == "publication"
+        assert refreshed.developmental_rewrite_enabled is True
+        assert refreshed.chapters[0].content == final_edit
+        event_types = [event.event_type for event in refreshed.events]
+        assert "publication_developmental_plan_supplemented" in event_types
+        assert "developmental_chapter_revision_completed" in event_types
+        assert "publication_chapter_humanization_completed" in event_types
+        compression_event = next(event for event in refreshed.events if event.event_type == "publication_chapter_compression_completed")
+        assert compression_event.payload["word_delta"] < 0
+        readiness_event = next(event for event in refreshed.events if event.event_type == "publication_readiness_completed")
+        assert readiness_event.payload["label"] == "needs editorial revision"
+        stages = {attempt.stage for attempt in refreshed.stage_attempts}
+        assert "chapter_humanization" in stages
+        assert "chapter_compression" in stages
+        qa_artifact = next(artifact for artifact in refreshed.artifacts if artifact.kind == "qa-report")
+        qa_text = (settings.artifacts_dir / qa_artifact.relative_path).read_text(encoding="utf-8")
+        assert "## Publication Readiness" in qa_text
 
 
 def test_canonical_entity_collision_hard_fails_run(configured_environment) -> None:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -9,8 +9,11 @@ from novel_generator.services.prompts import (
     build_chapter_revision_messages,
     build_continuity_update_messages,
     build_outline_chunk_messages,
+    build_outline_messages,
     build_developmental_rewrite_messages,
     build_manuscript_qa_messages,
+    build_publication_compression_messages,
+    build_publication_humanization_messages,
     build_story_bible_messages,
     parse_chapter_critique,
     parse_chapter_plan,
@@ -1172,6 +1175,99 @@ def test_prompt_builders_include_prose_voice_profile() -> None:
     assert "add or sharpen the planned independent_side_character_move" in revision_prompt
     assert "voice_and_texture" in revision_prompt
     assert "do not copy exact language" in revision_prompt
+
+
+def test_publication_profile_prompts_include_character_variety_and_compression_controls() -> None:
+    project = Project(
+        title="The Glass Orchard",
+        premise="An archivist finds a living map under a failing city.",
+        desired_word_count=64000,
+        requested_chapters=32,
+        min_words_per_chapter=1800,
+        max_words_per_chapter=2400,
+        preferred_model="test-model",
+        story_brief={"tone": "wet civic fantasy", "style_avoid": ["repeated copper pressure"]},
+    )
+    run = GenerationRun(
+        model_name="test-model",
+        target_word_count=64000,
+        requested_chapters=32,
+        min_words_per_chapter=1800,
+        max_words_per_chapter=2400,
+        quality_profile="publication",
+    )
+    chapter = ChapterDraft(
+        chapter_number=1,
+        title="Signal",
+        outline_summary="Iris follows the map.",
+        content="Iris follows the map. Tarin explains the system.",
+        status=ChapterStatus.PENDING,
+    )
+    chapter.run = run
+    story_bible = {
+        "genre_profile": "sci_fi_thriller",
+        "logline": "Iris follows a living map.",
+        "theme": "Consent beats control.",
+        "act_plan": ["Discovery", "Descent", "Choice"],
+        "cast": [{"name": "Iris", "role": "Archivist", "desire": "Restore the city", "risk": "Losing herself"}],
+        "character_agendas": [],
+        "canon_registry": [],
+        "conflict_ladder": ["Map wakes"],
+        "world_rules": [],
+        "core_system_rules": [],
+        "prose_guardrails": [],
+        "genre_contract": [],
+        "style_profile": {"character_voice_map": {"Iris": "Precise, evasive"}, "avoid": ["copper pressure"]},
+        "ending_promise": "Iris chooses consent over order.",
+    }
+    outline_entry = {
+        "chapter_number": 1,
+        "act": "Act I",
+        "title": "Signal",
+        "objective": "Find the map.",
+        "conflict_turn": "The archive locks.",
+        "character_turn": "Iris admits fear.",
+        "reveal": "The map is alive.",
+        "ending_state": "Iris commits.",
+        "chapter_mode": "investigation",
+        "concrete_ending_hook": {"trigger": "door locks", "visible_object_or_actor": "map", "next_problem": "escape"},
+    }
+    plan = {
+        "chapter_mode": "investigation",
+        "scene_beats": ["Iris finds the map"],
+        "story_turn": {
+            "irreversible_change": "The map wakes.",
+            "protagonist_choice": "Iris follows it.",
+            "choice_alternatives": ["Leave"],
+            "permanent_consequence": "The archive marks her.",
+            "why_this_chapter_cannot_be_cut": "The map bond begins.",
+            "state_before": "No bond.",
+            "state_after": "Marked.",
+        },
+    }
+    qa_report = ManuscriptQaReport(
+        repetition_risks=["Repeated pressure language."],
+        side_character_agency_notes=["Tarin only explains."],
+    )
+    ledger = {}
+
+    story_prompt = build_story_bible_messages(project, run)[1]["content"]
+    outline_prompt = build_outline_messages(project, run, story_bible)[1]["content"]
+    draft_prompt = build_chapter_draft_messages(project, run, chapter, outline_entry, story_bible, ledger, "", plan)[1]["content"]
+    humanize_prompt = build_publication_humanization_messages(project, chapter, outline_entry, story_bible, ledger, qa_report)[1]["content"]
+    compression_prompt = build_publication_compression_messages(project, chapter, outline_entry, story_bible, ledger, qa_report)[1]["content"]
+
+    assert "private wants, fears, resentments, tenderness" in story_prompt
+    assert "motif budget" in story_prompt
+    assert "quiet relationship scenes" in outline_prompt
+    assert "avoid repeating enter-location -> debate-system" in outline_prompt
+    assert "draft-long-then-cut target" in draft_prompt
+    assert "2070-2760 words" in draft_prompt
+    assert "ordinary human beat" in draft_prompt
+    assert "not embodiments of disciplines" in humanize_prompt
+    assert "fear, jealousy, tenderness, humor" in humanize_prompt
+    assert "trim 15-25%" in compression_prompt
+    assert "damp, brine, pressure, resonance" in compression_prompt
 
 
 def test_rolling_context_uses_recent_completed_chapters() -> None:

--- a/tests/test_ui_routes.py
+++ b/tests/test_ui_routes.py
@@ -287,6 +287,8 @@ def test_project_detail_renders_quality_profile_controls_and_preflight(client, m
     assert 'data-quality-profile-control' in response.text
     assert 'name="quality_profile"' in response.text
     assert 'value="balanced"' in response.text
+    assert 'value="publication"' in response.text
+    assert "Highest-cost editorial path" in response.text
     assert "Run preflight" in response.text
     assert 'data-run-preflight' in response.text
     assert 'href="#queue-run"' in response.text
@@ -820,12 +822,23 @@ def test_completed_run_can_create_publication_export(client, monkeypatch) -> Non
 
     detail_response = client.get(f"/runs/{run_id}")
     assert detail_response.status_code == 200
-    assert "Export For Publication" in detail_response.text
+    assert "Export Layout Helper" in detail_response.text
     assert 'value="print_5x8"' in detail_response.text
+    assert 'name="author_name"' in detail_response.text
+    assert 'name="dedication"' in detail_response.text
 
     response = client.post(
         f"/runs/{run_id}/publication-export",
-        data={"profile_id": "print_5x8", "include_ai_disclosure": "1"},
+        data={
+            "profile_id": "print_5x8",
+            "include_ai_disclosure": "1",
+            "author_name": "Nora Page",
+            "copyright_year": "2026",
+            "publisher": "Patchwork Press",
+            "dedication": "For readers who check the seams.",
+            "author_note": "This is a test note.",
+            "ai_disclosure": "AI assistance was used under human direction.",
+        },
         follow_redirects=False,
     )
 


### PR DESCRIPTION
## Summary
- Add an opt-in publication quality profile that forces outline approval, developmental rewrite, humanization, compression, final editing, and a readiness QA gate.
- Strengthen publication prompts around private character life, scene variety, motif budgets, and draft-long-then-cut prose compression.
- Add deterministic manuscript diagnostics for repeated atmosphere, similar openings, abstract-noun clusters, and discipline-label dialogue.
- Require real publication export front matter and rename exports as layout helpers unless readiness passes.

## Validation
- docker compose exec -T web python -m pytest
- /api/health returned 200 after restart
- Project/run detail pages returned 200
- Playwright screenshot verified project run controls at desktop width

## Notes
- Existing draft, balanced, and strict profiles remain compatible.
- No database migration is required for publication front matter because export metadata is supplied at export time.